### PR TITLE
docs: release v1.2.10 runtime-validated corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the LERP (Luau Education for Rive Professionals) course a
 
 ---
 
+## [1.2.10] — 2026-06-12
+
+All items in this release were validated live in the Rive Early Access editor (2026-06-11) using instrumented probe Node scripts and Test-protocol runtime checks driven through the Rive MCP, cross-checked against the editor's built-in scripting reference.
+
+### Added
+- **Node advance two-clock model (LERP-GAP-012)** — new "Playback vs Design Mode: The Two advance() Clocks" section in `docs/rive/protocols/node-lifecycle.mdx` plus an advance-semantics admonition in `docs/rive/protocols/node-protocol.mdx`: returning `false` unsubscribes from the playback advance loop only (a false-returning probe received zero advance calls during ~10 s of playback while drawing ~600 frames); `draw` is fully independent; design-mode `advance` fires as event-driven settle passes with `seconds = 0` and ignores the return value. Includes guard rules for time-based math.
+- **`Color.toFloat` in the Color reference** — surfaced in `docs/api/core-types.mdx` (previously only documented in the GPU shaders page) with runtime-confirmed output values.
+- **Color runtime representation** — documented that `Color` is a plain Luau `number` (ARGB packed integer) and that raw hex literals such as `0xFFFF0000` are valid `Color` values.
+- **Vector `z` component and `[3]` indexing** — documented in `docs/api/core-types.mdx` (always `0` for 2D vectors; populated by 3D APIs such as `Mat4:transformPoint`).
+- **Errata tracker entries** — added LERP-ERR-011, LERP-GAP-012, LERP-ERR-013, and LERP-GAP-014 with live-probe evidence, including the upstream Rive report (the editor reference's `Paint.with` example uses `Color.hex`, which does not exist at runtime, and its `advance` comment contradicts measured behavior).
+
+### Fixed
+- **Node `draw` requirement (LERP-ERR-011)** — `draw` was incorrectly documented as required for a Node script to appear in the add-to-scene menu. Editor-validated: a draw-less script compiles cleanly, appears in the menu, places as a script node, and runs `init`/`advance`. Updated the requirements block, protocol table, AE/JS comparison, common-mistakes section, exercise premise, and quiz `node-protocol-q1` in `docs/rive/protocols/node-protocol.mdx`.
+- **Deprecated Vector instance-method usage (LERP-ERR-013)** — the glossary Vector entry and the environment Vector exercise still taught `vec:length()` / `vec:normalized()` despite the core-types deprecation table; both now use static `Vector.length(...)` / `Vector.normalized(...)`.
+- **Styling/Path reference drift (LERP-GAP-014)** — `PaintDefinition.gradient` is now typed `(Gradient | false)?` with a note that assigning `false` also clears the live `paint.gradient` property (reads back `nil`); the path mutation rule is now stated generally (any mutation after drawing requires waiting a frame, not just `reset()`); `path:add` accepts any `PathData`; `positionAndTangent` documents distance clamping and the normalized tangent; `extract` documents clamping and the `startWithMove` default of `true`.
+
+### Changed
+- **Course metadata refresh** — sidebar "Last reviewed" date updated for this errata pass.
+
+---
+
 ## [1.2.9] — 2026-06-04
 
 ### Added

--- a/docs/api/core-types.mdx
+++ b/docs/api/core-types.mdx
@@ -67,6 +67,11 @@ The X component. **Type:** `number` (read-only)
 #### `vec.y`
 The Y component. **Type:** `number` (read-only)
 
+#### `vec.z`
+The Z component. **Type:** `number` (read-only)
+
+Always `0` for vectors created with `Vector.xy()`. Populated by 3D APIs that return a `Vector`, such as [`Mat4:transformPoint`](#mat4). Editor-validated: `Vector.xy(1, 2).z` returns `0`.
+
 ### Indexing
 
 Vectors support indexed access:
@@ -75,6 +80,7 @@ Vectors support indexed access:
 local v = Vector.xy(10, 20)
 print(v[1])  -- 10 (x component)
 print(v[2])  -- 20 (y component)
+print(v[3])  -- 0  (z component)
 ```
 
 ### Static Methods (Preferred)
@@ -376,6 +382,28 @@ local startColor = Color.rgb(255, 0, 0)  -- Red
 local endColor = Color.rgb(0, 0, 255)    -- Blue
 local purple = Color.lerp(startColor, endColor, 0.5)
 ```
+
+#### `Color.toFloat(color)`
+
+Converts a Color (ARGB packed integer) to an `{r, g, b, a}` array table with values in the 0.0–1.0 range. Primarily used with `clearColor` in GPU render passes.
+
+```lua
+Color.toFloat(color: Color): { number }
+```
+
+**Example:**
+```lua
+local cc = Color.toFloat(Color.rgba(255, 0, 0, 128))
+-- cc = { 1.0, 0.0, 0.0, 0.502 }
+```
+
+Editor-validated 2026-06-11: `type(Color.toFloat)` is `function`; the example above returns exactly `{1, 0, 0, 0.5019607843137255}`.
+
+See [GPU Shaders](/api/gpu-shaders) for usage in render pass descriptors.
+
+### Runtime Representation
+
+A `Color` is a plain Luau `number` at runtime — an ARGB packed integer. `type(Color.rgb(255, 0, 0))` returns `"number"`, and raw packed values such as `0xFFFF0000` are accepted anywhere a `Color` is expected (`0xFFFF0000 == Color.rgb(255, 0, 0)`). Prefer the `Color.*` constructors for readability, but raw hex literals are not an error.
 
 **See Also:** [<Term>Paint</Term>](./drawing#paint), [Gradient](./drawing#gradient), [GradientStop](./styling#gradientstop)
 

--- a/docs/api/drawing.mdx
+++ b/docs/api/drawing.mdx
@@ -84,12 +84,16 @@ Clears all path data. **Warning:** Don't call while rendering.
 path:reset()
 ```
 
+:::warning Mutation rule
+An unchanged path can be drawn multiple times per frame. But once a path has been drawn (passed to `renderer:drawPath`), **any** mutation — `moveTo`, `lineTo`, `cubicTo`, `add`, `reset`, etc. — must wait until the next frame before the path can be drawn again. The `reset()` warning above is one case of this general rule.
+:::
+
 #### `path:add(other, transform?)`
 
-Merges another path into this one.
+Merges another path (or any `PathData`, such as the input collection a Path Effect receives) into this one.
 
 ```lua
-path:add(other: Path, transform?: Mat2D)
+path:add(other: PathData | Path, transform?: Mat2D)
 ```
 
 #### `path:measure()`
@@ -150,13 +154,13 @@ True only if the path has exactly one closed contour. **Type:** `boolean` (read-
 
 #### `measure:positionAndTangent(distance)`
 
-Returns the position and tangent at a distance along the path.
+Returns the position and tangent at a distance along the path. The distance is clamped to `[0, measure.length]`, and the returned tangent is a normalized (unit) vector.
 
 ```lua
 measure:positionAndTangent(distance: number): Vector, Vector
 ```
 
-**Returns:** position, tangent (both Vector)
+**Returns:** position, normalized tangent (both Vector)
 
 **Example:**
 ```lua
@@ -200,7 +204,7 @@ local rightOffset = measure:warp(Vector.xy(measure.length * 0.5, -10))
 
 #### `measure:extract(start, end, dest, startWithMove?)`
 
-Extracts a segment into a destination path.
+Extracts a segment into a destination path. Distances are clamped to `[0, measure.length]`. `startWithMove` defaults to `true` (the segment begins with a `moveTo`); pass `false` to continue from the destination path's previous point — useful when stitching a wrap-around extraction from two calls.
 
 ```lua
 measure:extract(startDist: number, endDist: number, dest: Path, startWithMove?: boolean)
@@ -320,11 +324,13 @@ type PaintDefinition = {
     join: ("round" | "bevel" | "miter")?, -- Corner style (stroke only)
     blendMode: BlendMode?,             -- Compositing mode
     feather: number?,                  -- Feathering amount
-    gradient: Gradient?,               -- Applied gradient
+    gradient: (Gradient | false)?,     -- Applied gradient (false removes an existing gradient)
 }
 ```
 
 All fields are optional. Unspecified fields use Paint defaults.
+
+Setting `gradient = false` removes an existing gradient — useful with `paint:copy()` to derive a solid-color paint from a gradient paint. Editor-validated: assigning `false` to the live `paint.gradient` property also works and the property reads back as `nil` afterwards.
 
 **Example:**
 ```lua
@@ -348,7 +354,7 @@ local stroke = Paint.with({
 | `join` | `"round"`, `"bevel"`, `"miter"` | Corner style (stroke only) |
 | `blendMode` | BlendMode | Compositing mode |
 | `feather` | number | Feathering amount |
-| `gradient` | Gradient? | Applied gradient |
+| `gradient` | Gradient? | Applied gradient (assign `false` to remove; reads back as `nil`) |
 
 ### Methods
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -10,6 +10,27 @@ All notable changes to the LERP (Luau Education for Rive Professionals) course a
 
 ---
 
+## [1.2.10] — 2026-06-12
+
+All items in this release were validated live in the Rive Early Access editor (2026-06-11) using instrumented probe Node scripts and Test-protocol runtime checks driven through the Rive MCP, cross-checked against the editor's built-in scripting reference.
+
+### Added
+- **Node advance two-clock model (LERP-GAP-012)** — new "Playback vs Design Mode: The Two advance() Clocks" section in `rive/protocols/node-lifecycle` plus an advance-semantics admonition in `rive/protocols/node-protocol`: returning `false` unsubscribes from the playback advance loop only (a false-returning probe received zero advance calls during ~10 s of playback while drawing ~600 frames); `draw` is fully independent; design-mode `advance` fires as event-driven settle passes with `seconds = 0` and ignores the return value. Includes guard rules for time-based math.
+- **`Color.toFloat` in the Color reference** — surfaced in `api/core-types` (previously only documented in the GPU shaders page) with runtime-confirmed output values.
+- **Color runtime representation** — documented that `Color` is a plain Luau `number` (ARGB packed integer) and that raw hex literals such as `0xFFFF0000` are valid `Color` values.
+- **Vector `z` component and `[3]` indexing** — documented in `api/core-types` (always `0` for 2D vectors; populated by 3D APIs such as `Mat4:transformPoint`).
+- **Errata tracker entries** — added LERP-ERR-011, LERP-GAP-012, LERP-ERR-013, and LERP-GAP-014 with live-probe evidence, including the upstream Rive report (the editor reference's `Paint.with` example uses `Color.hex`, which does not exist at runtime, and its `advance` comment contradicts measured behavior).
+
+### Fixed
+- **Node `draw` requirement (LERP-ERR-011)** — `draw` was incorrectly documented as required for a Node script to appear in the add-to-scene menu. Editor-validated: a draw-less script compiles cleanly, appears in the menu, places as a script node, and runs `init`/`advance`. Updated the requirements block, protocol table, AE/JS comparison, common-mistakes section, exercise premise, and quiz `node-protocol-q1` in `rive/protocols/node-protocol`.
+- **Deprecated Vector instance-method usage (LERP-ERR-013)** — the glossary Vector entry and the environment Vector exercise still taught `vec:length()` / `vec:normalized()` despite the core-types deprecation table; both now use static `Vector.length(...)` / `Vector.normalized(...)`.
+- **Styling/Path reference drift (LERP-GAP-014)** — `PaintDefinition.gradient` is now typed `(Gradient | false)?` with a note that assigning `false` also clears the live `paint.gradient` property (reads back `nil`); the path mutation rule is now stated generally (any mutation after drawing requires waiting a frame, not just `reset()`); `path:add` accepts any `PathData`; `positionAndTangent` documents distance clamping and the normalized tangent; `extract` documents clamping and the `startWithMove` default of `true`.
+
+### Changed
+- **Course metadata refresh** — sidebar "Last reviewed" date updated for this errata pass.
+
+---
+
 ## [1.2.9] — 2026-06-04
 
 ### Added

--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -1564,8 +1564,8 @@ local zero = Vector.origin()
 -- Operations
 local sum = pos + Vector.xy(10, 20)
 local scaled = pos * 2
-local length = pos:length()
-local normalized = pos:normalized()
+local length = Vector.length(pos)
+local normalized = Vector.normalized(pos)
 ```
 
 **Learn more:** [Core Types](/advanced/core-types)

--- a/docs/rive/environment.mdx
+++ b/docs/rive/environment.mdx
@@ -391,8 +391,8 @@ function init(self: VectorPractice, context: Context): boolean
     -- TODO 3: Calculate the difference (finish - start)
     local diff = finish - start
 
-    -- TODO 4: Calculate the distance using diff:length()
-    local distance = diff:length()
+    -- TODO 4: Calculate the distance using Vector.length(diff)
+    local distance = Vector.length(diff)
 
     print(`Start: ({start.x}, {start.y})`)
     print(`Finish: ({finish.x}, {finish.y})`)

--- a/docs/rive/protocols/node-lifecycle.mdx
+++ b/docs/rive/protocols/node-lifecycle.mdx
@@ -77,7 +77,7 @@ Rive calls your script functions in a specific order. Understanding this lets yo
 **Lifecycle order:**
 1. `init(self, context)` - runs once at startup
 2. `update(self)` - runs when any <Term>Input</Term> changes (NO context param!)
-3. `advance(self, seconds)` - runs every animation frame (logic)
+3. `advance(self, seconds)` - runs every playback frame (logic); at design time it only fires as zero-delta settle passes
 4. `drawCanvas(self)` - runs during the canvas render phase for offscreen `Canvas` / `GPUCanvas` work
 5. `draw(self, renderer)` - runs on canvas repaint (normal renderer compositing, keep pure!)
 
@@ -91,7 +91,7 @@ Pointer event handlers (`pointerDown`, `pointerMove`, etc.) run when the user in
 |----------|---------|-----------|------------------|
 | **init** | Create paths, paints, listeners, long-lived objects | Once | `constructor()` |
 | **update** | Respond to input changes; rebuild paths or cached values | On input change | `componentDidUpdate()` |
-| **advance** | Update time-based state (movement, physics, timers) | Every animation frame | `requestAnimationFrame` logic |
+| **advance** | Update time-based state (movement, physics, timers) | Every playback frame (design mode: settle passes only) | `requestAnimationFrame` logic |
 | **drawCanvas** | Render into offscreen `Canvas` / `GPUCanvas` targets | During canvas render phase | WebGL/WebGPU render pass |
 | **draw** | Issue <Term>Renderer</Term> commands only (no state changes!) | On canvas repaint | Canvas `ctx.draw()` calls |
 
@@ -102,6 +102,28 @@ Put expensive work in `update` or `init`, not in `draw` or `advance`. Rebuilding
 :::info Shader and offscreen canvas rule
 Call `Canvas:beginFrame(...)` and `GPUCanvas:beginRenderPass(...)` from `drawCanvas(self)`. Composite the resulting `canvas.image` or `gpuCanvas.image` from `draw(self, renderer)`.
 :::
+
+---
+
+## Playback vs Design Mode: The Two advance() Clocks
+
+`advance` runs against two very different schedulers depending on whether the artboard is playing. All of the following was validated live in the Rive Early Access editor (2026-06-11) with instrumented probe scripts:
+
+| | Playback (Play / runtime) | Design mode (editing) |
+|---|---|---|
+| `advance` cadence | Every frame (~60/s) | Event-driven settle passes only (object moves, pointer over canvas, adds, recompiles) |
+| `seconds` (delta) | Real elapsed time | **Always `0`** — no clock exists; accumulated time never grows |
+| `return false` | Unsubscribes this instance from the advance loop | **Ignored** — editor events keep re-advancing the node |
+| `draw` | Every frame, independent of advance | Every repaint, independent (camera pan/zoom repaints without advancing) |
+
+The probe evidence: a node whose `advance` returned `false` received **zero** advance calls during ~10 seconds of playback while drawing ~600 frames alongside an always-`true` node ticking at exactly 60/s. The same false-returning node was re-advanced 200+ times by design-mode editor events with `seconds = 0` on every call.
+
+**Practical rules:**
+
+- Never divide by `seconds` or assume it is non-zero — design-mode settle passes always pass `0`. Guard time-based math: `if seconds > 0 then ... end`.
+- Returning `false` from `advance` is a real playback optimization for nodes that have finished animating — but it does not stop `draw`, and it does not reduce design-time work.
+- A node that returns `false` still needs its `draw` to render current state on every repaint.
+- `draw` can fire before the first `advance` — never rely on advance having run.
 
 ---
 

--- a/docs/rive/protocols/node-protocol.mdx
+++ b/docs/rive/protocols/node-protocol.mdx
@@ -36,7 +36,7 @@ import Term from '@site/src/components/Term';
 | Constructor | `constructor() { }` | `init(self, context)` |
 | Instance method | `this.method()` | `function method(self)` |
 | Factory pattern | `new MyClass()` or `createInstance()` | `return function(): Node<T>` |
-| Required interface | `implements Interface` | Must have `init` and `draw` |
+| Required interface | `implements Interface` | Must return a factory; implement the lifecycle functions you need |
 | Export | `export default` or `module.exports` | `return function(): Node<T>` |
 
 :::danger Critical Difference: The Factory Function Pattern
@@ -67,15 +67,15 @@ Why? This pattern lets Rive:
 
 ## Rive Context: A Node Script Is Not a Normal Luau File
 
-Node scripts run **inside Rive** and must follow a protocol. The editor only lists scripts that return a factory function with at least `init` and `draw`.
+Node scripts run **inside Rive** and must follow a protocol. The editor lists scripts that return a factory function matching the Node protocol.
 
 **Minimum requirements:**
 1. Exported type for script state (`export type`)
-2. `init(self, context)` and `draw(self, renderer)` functions
-3. `return function(): Node<YourType>` factory function
+2. `return function(): Node<YourType>` factory function
+3. In practice, an `init(self, context)` function — every real script needs setup
 
-:::warning Important
-If `draw` is missing, the script will not appear in the add-to-scene menu. This is a common source of confusion for beginners.
+:::info draw is optional
+`draw` is **not** required for a script to appear in the add-to-scene menu. Editor-validated (Early Access, 2026-06-11): a Node script with only `init` and `advance` compiles cleanly, appears in the add menu, places as a script node, and runs its lifecycle — it just renders nothing. Omit `draw` for logic-only scripts (timers, data orchestration); this also avoids an unnecessary per-repaint call. Include `draw` whenever the script renders.
 :::
 
 ---
@@ -217,9 +217,9 @@ Every Node script you write will follow this structure. The exported type define
 | Function | Required | Parameters | Return | Called When |
 |----------|----------|------------|--------|-------------|
 | `init` | ✅ Yes | `self`, `context` | `boolean` | Once at startup |
-| `draw` | ✅ Yes | `self`, `renderer` | none | On canvas repaint |
+| `draw` | Optional (needed to render) | `self`, `renderer` | none | On canvas repaint |
 | `update` | Optional | `self` | none | <Term>Input</Term> changes |
-| `advance` | Optional | `self`, `seconds` | `boolean` | Every animation frame |
+| `advance` | Optional | `self`, `seconds` | `boolean` | Every playback frame; design-mode settle passes (see below) |
 | `drawCanvas` | Optional | `self` | none | Canvas/GPU render phase before `draw` |
 | `pointerDown` | Optional | `self`, `event: PointerEvent` | none | Mouse/touch down |
 | `pointerMove` | Optional | `self`, `event: PointerEvent` | none | Mouse/touch move |
@@ -228,6 +228,16 @@ Every Node script you write will follow this structure. The exported type define
 
 :::info GPU and offscreen canvas callback
 Use `drawCanvas(self)` for `Canvas:beginFrame(...)` and `GPUCanvas:beginRenderPass(...)` work. Use `draw(self, renderer)` afterward to composite the resulting `canvas.image` or `gpuCanvas.image`.
+:::
+
+:::info advance() return value — playback vs design mode
+`advance` behaves differently depending on whether the artboard is playing (editor-validated, Early Access, 2026-06-11):
+
+**Playback (Play button / runtime):** `advance` is called every frame with real delta time. Return `true` to keep receiving advance calls; return `false` to unsubscribe this instance from the advance loop. `draw` is fully independent — it keeps firing on every repaint either way (a false-returning test node received zero advance calls during ~10 s of playback while drawing ~600 frames).
+
+**Design mode (editing, not playing):** there is no advance loop and no clock. `advance` fires as a settle pass with `seconds = 0` whenever the artboard changes (moving objects, pointer over the canvas, recompiles), and the return value is ignored. Elapsed time never accumulates at design time.
+
+Practical rules: never divide by `seconds` or assume it is non-zero; returning `false` is a playback optimization for nodes that have finished animating, not a way to stop drawing; `draw` can also fire before the first `advance`.
 :::
 
 ---
@@ -258,7 +268,7 @@ A Node script is added as its own script node in the artboard hierarchy. Nesting
 
 ### Premise
 
-Every Node script must have init() and draw() functions. init() runs once when the script starts and is the place to print debug messages and set up initial state.
+Node scripts implement lifecycle functions such as init() and draw(). init() runs once when the script starts and is the place to print debug messages and set up initial state.
 
 :::info Goal
 By the end of this exercise, you will be able to Complete the init function to print a greeting message and the answer. The script structure (export type, factory function) is already provided.
@@ -738,15 +748,15 @@ ANSWER: complete
 ## Knowledge Check
 
 <Quiz
-  question="What is the minimum set of functions required for a Node script to appear in Rive's add-to-scene menu?"
+  question="Is the draw function required for a Node script to appear in the add-to-scene menu?"
   id="node-protocol-q1"
   options={[
-    { text: "init only" },
-    { text: "draw only" },
-    { text: "init and draw", correct: true },
-    { text: "init, advance, and draw" },
+    { text: "Yes — scripts without draw are hidden from the menu" },
+    { text: "No — a draw-less script lists, places, and runs init/advance; it just renders nothing", correct: true },
+    { text: "Only if the script also defines advance" },
+    { text: "Yes, and it must contain at least one renderer call" },
   ]}
-  explanation="A Node script must have at least init and draw functions to be recognized by Rive. The draw function is specifically required for the script to appear in the add-to-scene menu."
+  explanation="Editor-validated (Early Access, 2026-06-11): a Node script with no draw function compiles cleanly, appears in the add menu, places as a script node, and runs init/advance normally. Omit draw for logic-only scripts; include it whenever the script renders."
 />
 
 <Quiz
@@ -804,22 +814,24 @@ return function(): Node<MyNode>
 end
 ```
 
-### 2. Forgetting draw (Even If Empty)
+### 2. Expecting Visuals Without draw
 
 ```lua
--- WRONG: No draw function
+-- VALID but renders nothing: draw-less scripts list, place, and run
 return function(): Node<MyNode>
-    return { init = init }  -- Script won't appear in menu!
+    return { init = init, advance = advance }  -- Fine for logic-only scripts
 end
 
--- CORRECT: Include draw even if empty
+-- To actually render, include draw:
 return function(): Node<MyNode>
     return {
         init = init,
-        draw = draw,  -- Required!
+        draw = draw,  -- Needed for anything visual
     }
 end
 ```
+
+A script node that "doesn't show up on the canvas" usually isn't broken — it just has no `draw` (or its `draw` issues no renderer commands). Omitting `draw` on purpose is a valid optimization for timers and data-orchestration scripts.
 
 ### 3. Factory vs init() Object Creation
 

--- a/docs/rive/rive-doc-errata.mdx
+++ b/docs/rive/rive-doc-errata.mdx
@@ -12,6 +12,7 @@ keywords:
 # LERP Rive Documentation Errata Tracker
 
 Last revalidated against runtime baseline: 2026-06-04 (`2.37.8` public npm line; source-level API snapshot `runtime-v0.1.106` / `5360c834`; shader/GPU editor workflow remains Early Access only)
+Last editor-validated errata batch: 2026-06-12 (Rive Early Access editor, live instrumented probe scripts and Test-protocol runtime checks via the Rive MCP)
 Initial errata tracker open date: 2026-04-26
 
 Purpose: record LERP documentation inconsistencies, inaccuracies, and materially misleading gaps discovered while validating live Rive Editor behavior and current official Rive docs.
@@ -38,6 +39,10 @@ Entries are ordered newest first (freshest updates at the top).
 
 | ID | Area | Status | Severity | Short finding |
 |---|---|---|---|---|
+| LERP-ERR-011 | Node protocol | resolved | high | Resolved in LERP on 2026-06-12: `draw` was documented as required for add-menu listing; editor-validated that draw-less Node scripts list, place, and run. |
+| LERP-GAP-012 | Node advance semantics | resolved | high | Resolved in LERP on 2026-06-12: documented the playback-vs-design-mode advance model — `return false` unsubscribes from the playback advance loop only, `draw` is independent, design-mode settle passes always pass `seconds = 0` and ignore the return value. |
+| LERP-ERR-013 | Vector deprecated usage | resolved | low | Resolved in LERP on 2026-06-12: glossary and environment exercise still taught deprecated `vec:length()` style despite the core-types deprecation table; switched to static `Vector.*` calls. |
+| LERP-GAP-014 | Styling/Path API drift | resolved | medium | Resolved in LERP on 2026-06-12: `PaintDefinition.gradient` now typed `(Gradient \| false)?`, `Color.toFloat` surfaced in core-types, Color documented as a raw packed number, Vector `z`/`[3]` documented, general path mutate-after-draw rule added, `extract`/`positionAndTangent` clamping and defaults documented. |
 | LERP-ERR-010 | Exercise validator whitespace feedback | resolved | high | Resolved in LERP on 2026-06-04 after a report from Rive Community user [Avo](https://community.rive.app/u/7a2efe62): failed-answer boxes now preserve exact whitespace and warn on whitespace-only mismatches. |
 | LERP-GAP-009 | Script save/recompile workflow | resolved | medium | Resolved in LERP on 2026-06-04 after a report from Rive Community user [Avo](https://community.rive.app/u/7a2efe62): first-script onboarding now explains the blue save-state dot and save-to-recompile behavior. |
 | LERP-GAP-008 | Node script placement | resolved | medium | Resolved in LERP on 2026-06-04 after a report from Rive Community user [Avo](https://community.rive.app/u/7a2efe62): docs now describe Node scripts as artboard script nodes and clarify nesting does not pass parent `NodeData` or `PathData` into callbacks. |
@@ -48,6 +53,122 @@ Entries are ordered newest first (freshest updates at the top).
 | LERP-GAP-003 | ViewModel context | resolved | medium | Resolved in LERP on 2026-04-26: `context:viewModel()` wording now describes immediate data-context behavior, with `context:rootViewModel()` explicitly documented for root/global state. |
 | LERP-ERR-002 | Path Effect / PathCommand | resolved | high | Resolved in LERP on 2026-04-26: Path Effect examples now use string command-name comparisons and clarify `CommandType` is not a guaranteed global table in editor scripts. |
 | LERP-ERR-001 | ListenerAction | resolved | high | Resolved in LERP on 2026-04-26: ListenerAction guidance now uses `performAction(self, listenerContext)` as preferred and marks `perform` legacy. |
+
+---
+
+## LERP-ERR-011 - draw incorrectly documented as required for add-menu listing
+
+Status: resolved in LERP 2026-06-12 (was confirmed)
+
+Severity: high
+
+Reported by:
+
+- Live editor validation (Rive Early Access, 2026-06-11): instrumented probe scripts placed and run via the Rive MCP
+
+Affected local docs before fix:
+
+- `/Users/ivg/github/lerp/docs/rive/protocols/node-protocol.mdx`
+
+Evidence:
+
+- A Node script with only `init` and `advance` (no `draw`) compiled with zero diagnostics, appeared in the add-to-scene menu, was placed as a script node (`ScriptedDrawable`), and ran `init`/`advance` normally.
+- LERP claimed "If `draw` is missing, the script will not appear in the add-to-scene menu" and quiz `node-protocol-q1` keyed "init and draw" as the required minimum.
+
+Why this matters:
+
+Learners building logic-only scripts (timers, orchestration) were told to add an empty `draw`, which adds an unnecessary per-repaint call; and the false claim misdirects debugging when a script "doesn't show up."
+
+Fix implemented in LERP (2026-06-12):
+
+- Requirements block, protocol table, AE/JS comparison row, common-mistake section, exercise premise, and quiz `node-protocol-q1` updated: `draw` is optional and only needed for rendering.
+
+---
+
+## LERP-GAP-012 - Node advance return semantics and design-mode clock undocumented
+
+Status: resolved in LERP 2026-06-12 (was gap)
+
+Severity: high
+
+Reported by:
+
+- Live editor validation (Rive Early Access, 2026-06-11): paired probe nodes (`advance` returning `false` after 3 calls vs always `true`) instrumented with per-call prints, observed across design-mode interaction and ~10 s of playback
+
+Affected local docs before fix:
+
+- `/Users/ivg/github/lerp/docs/rive/protocols/node-protocol.mdx`
+- `/Users/ivg/github/lerp/docs/rive/protocols/node-lifecycle.mdx`
+
+Evidence:
+
+- Playback: the always-`true` node ticked at exactly 60/s with real accumulating delta; the `false`-returning node received zero advance calls while drawing ~600 frames in the same window — so `return false` unsubscribes from the advance loop and `draw` is fully independent.
+- Design mode: no advance loop and no clock exist; `advance` fired as settle passes with `seconds = 0` on artboard-dirtying events (object moves, pointer over canvas, recompiles), and the `false` return was ignored across 200+ event-driven re-advances.
+- The Rive editor's own built-in example comment ("returns true if it needs to keep drawing") is contradicted by this behavior and was reported upstream.
+
+Why this matters:
+
+Time-based scripts that divide by `seconds` break at design time (`seconds = 0`); scripts that return `false` expecting drawing to stop are misdesigned; LERP previously never defined the Node `advance` return value at all.
+
+Fix implemented in LERP (2026-06-12):
+
+- Added the "Playback vs Design Mode: The Two advance() Clocks" section to node-lifecycle and an advance-semantics admonition to node-protocol, including the practical guard rules.
+
+---
+
+## LERP-ERR-013 - Deprecated Vector instance methods still taught outside core-types
+
+Status: resolved in LERP 2026-06-12 (was confirmed)
+
+Severity: low
+
+Reported by:
+
+- Internal docs cross-validation against the editor scripting reference and `Vector` deprecation attributes (`@[deprecated{ use = "Vector.*" }]`)
+
+Affected local docs before fix:
+
+- `/Users/ivg/github/lerp/docs/glossary.mdx` (Vector entry used `pos:length()` / `pos:normalized()`)
+- `/Users/ivg/github/lerp/docs/rive/environment.mdx` (exercise TODO used `diff:length()`)
+
+Why this matters:
+
+`api/core-types.mdx` deprecates all seven Vector instance methods in favor of static `Vector.*` calls; teaching the deprecated style elsewhere contradicts the course's own guidance.
+
+Fix implemented in LERP (2026-06-12):
+
+- Both occurrences switched to `Vector.length(...)` / `Vector.normalized(...)`.
+
+---
+
+## LERP-GAP-014 - Styling and Path API reference drift vs editor scripting reference
+
+Status: resolved in LERP 2026-06-12 (was gap)
+
+Severity: medium
+
+Reported by:
+
+- Cross-validation of the editor's built-in scripting reference (`rive/paint`, `rive/color`, `rive/vector`, `rive/path` definitions) against LERP API pages, with runtime confirmation via Test-protocol scripts run in the Early Access editor (2026-06-11)
+
+Affected local docs before fix:
+
+- `/Users/ivg/github/lerp/docs/api/drawing.mdx`
+- `/Users/ivg/github/lerp/docs/api/core-types.mdx`
+
+Runtime-confirmed findings folded into this entry:
+
+- `PaintDefinition.gradient` is `(Gradient | false)?`; assigning `false` removes a gradient and also works on the live `paint.gradient` property (reads back `nil`).
+- `Color.toFloat(color)` exists (returns `{r, g, b, a}` in 0–1) but was only documented in the GPU shaders page; now surfaced in the core-types Color section.
+- `Color` is a plain Luau `number` (ARGB packed); raw literals like `0xFFFF0000` are valid and equal `Color.rgb(255, 0, 0)`.
+- `Vector` has a read-only `z` component and `[3]` indexing (`0` for 2D vectors; populated by 3D APIs such as `Mat4:transformPoint`).
+- The path mutation rule is general (any mutation after drawing requires waiting a frame), not just `reset()`; `path:add` accepts any `PathData`.
+- `positionAndTangent` clamps distance and returns a normalized tangent; `extract` clamps distances and `startWithMove` defaults to `true`.
+- Related upstream finding reported to Rive: the editor reference's `Paint.with` example uses `Color.hex('#FF0066')`, but `Color.hex` does not exist at runtime (`type(Color.hex)` is `nil`); LERP already used `Color.rgb(255, 0, 102)`.
+
+Fix implemented in LERP (2026-06-12):
+
+- All of the above documented in `api/drawing.mdx` and `api/core-types.mdx` with editor-validation notes.
 
 ---
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -190,7 +190,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'html',
       value:
-        '<div class="sidebar-author-meta"><strong>Author:</strong> IVG Design (I.V.Gusinski)<br/><strong>Last reviewed:</strong> June 4, 2026<br/><strong>Editorial standard:</strong> <a href="/apps/lerp/editorial-methodology">Methodology</a> · <a href="/apps/lerp/corrections-policy">Corrections Policy</a> · <a href="/apps/lerp/contact-transparency">Contact</a></div>',
+        '<div class="sidebar-author-meta"><strong>Author:</strong> IVG Design (I.V.Gusinski)<br/><strong>Last reviewed:</strong> June 12, 2026<br/><strong>Editorial standard:</strong> <a href="/apps/lerp/editorial-methodology">Methodology</a> · <a href="/apps/lerp/corrections-policy">Corrections Policy</a> · <a href="/apps/lerp/contact-transparency">Contact</a></div>',
       defaultStyle: false,
     },
   ],

--- a/static/.well-known/ai-feed.json
+++ b/static/.well-known/ai-feed.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generatedAt": "2026-06-04T22:20:47.866Z",
+  "generatedAt": "2026-06-12T09:44:17.229Z",
   "canonical": "https://forge.mograph.life/apps/lerp/",
   "site": {
     "name": "LERP",

--- a/static/ai-feed.json
+++ b/static/ai-feed.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generatedAt": "2026-06-04T22:20:47.866Z",
+  "generatedAt": "2026-06-12T09:44:17.229Z",
   "canonical": "https://forge.mograph.life/apps/lerp/",
   "site": {
     "name": "LERP",

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -1,5 +1,5 @@
 # LERP Full Knowledge Surface (llms-full)
-Generated: 2026-06-04T22:20:47.865Z
+Generated: 2026-06-12T09:44:17.227Z
 Canonical: https://forge.mograph.life/apps/lerp/
 Scope: Complete documentation route inventory with page metadata for AI retrieval and citation.
 


### PR DESCRIPTION
## Summary
Editor-validated documentation corrections from live Rive Early Access probe runs (2026-06-11), driven through the Rive MCP with instrumented Node scripts and Test-protocol runtime checks.

- **LERP-ERR-011** — Node `draw` is optional: draw-less scripts compile, appear in the add menu, place, and run `init`/`advance`. Fixed requirements block, protocol table, AE/JS comparison, common mistakes, exercise premise, and quiz `node-protocol-q1`.
- **LERP-GAP-012** — New "Playback vs Design Mode: The Two advance() Clocks" coverage: `return false` unsubscribes from the playback advance loop only; `draw` is independent; design-mode settle passes always pass `seconds = 0` and ignore the return value.
- **LERP-ERR-013** — Glossary and environment exercise switched off deprecated `vec:length()` style to static `Vector.*` calls.
- **LERP-GAP-014** — `PaintDefinition.gradient` typed `(Gradient | false)?`, `Color.toFloat` surfaced in core-types, Color documented as raw packed number, Vector `z`/`[3]`, general path mutate-after-draw rule, `extract`/`positionAndTangent` clamping and defaults.
- Errata tracker entries for all four findings; changelog (docs + root mirror); sidebar review date; regenerated AI artifacts.

Production build (`node scripts/build-with-landing.mjs`) passes.