### PR TITLE
docs: release v1.2.11 Exercise 3 winding fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the LERP (Luau Education for Rive Professionals) course a
 
 ---
 
+## [1.2.11] — 2026-06-12
+
+### Fixed
+- **Exercise 3 triangle winding (LERP-ERR-015)** — the Node Protocol drawing exercise (`docs/rive/protocols/node-protocol.mdx`) described its triangle points in counter-clockwise order, which the current clockwise-fill renderer does not draw, so following the exercise exactly produced an invisible shape. Point order corrected to clockwise. Reported by GitHub user [belal-sweileh](https://github.com/ivg-design/lerp/issues/2) in issue #2; reproduced live in the Early Access editor (2026-06-12) with a side-by-side CW/CCW probe.
+
+### Added
+- **Winding-direction guidance** — new warnings in the Exercise 3 premise, `docs/api/drawing.mdx`, and `docs/quick-reference.mdx`: fills require clockwise winding (y points down in artboard coordinates), and the scripting API currently exposes no fill-rule control on `Path` or `Paint`.
+- **Errata entry LERP-ERR-015** — full evidence trail for the winding behavior, including the runtime's clockwise fill pipeline.
+
+---
+
 ## [1.2.10] — 2026-06-12
 
 All items in this release were validated live in the Rive Early Access editor (2026-06-11) using instrumented probe Node scripts and Test-protocol runtime checks driven through the Rive MCP, cross-checked against the editor's built-in scripting reference.

--- a/docs/api/drawing.mdx
+++ b/docs/api/drawing.mdx
@@ -132,6 +132,10 @@ path:lineTo(Vector.xy(0, 100))
 path:close()
 ```
 
+:::warning Winding direction matters for fills
+The current renderer fills **clockwise-wound** contours (in artboard coordinates, where y points down). A single counter-clockwise contour renders invisible with a fill paint — editor-validated 2026-06-12 with side-by-side CW/CCW triangles. Order your points clockwise, like the example above (top → bottom-right → bottom-left). The scripting API currently exposes no fill-rule control on `Path` or `Paint`.
+:::
+
 **See Also:** [PathMeasure](#pathmeasure), [Renderer.drawPath](#rendererdrawpathpath-paint)
 
 ---

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -10,6 +10,17 @@ All notable changes to the LERP (Luau Education for Rive Professionals) course a
 
 ---
 
+## [1.2.11] — 2026-06-12
+
+### Fixed
+- **Exercise 3 triangle winding (LERP-ERR-015)** — the Node Protocol drawing exercise described its triangle points in counter-clockwise order, which the current clockwise-fill renderer does not draw, so following the exercise exactly produced an invisible shape. Point order corrected to clockwise. Reported by GitHub user [belal-sweileh](https://github.com/ivg-design/lerp/issues/2) in issue #2; reproduced live in the Early Access editor (2026-06-12) with a side-by-side CW/CCW probe.
+
+### Added
+- **Winding-direction guidance** — new warnings in the Exercise 3 premise, the Path API reference, and the quick reference: fills require clockwise winding (y points down in artboard coordinates), and the scripting API currently exposes no fill-rule control on `Path` or `Paint`.
+- **Errata entry LERP-ERR-015** — full evidence trail for the winding behavior, including the runtime's clockwise fill pipeline.
+
+---
+
 ## [1.2.10] — 2026-06-12
 
 All items in this release were validated live in the Rive Early Access editor (2026-06-11) using instrumented probe Node scripts and Test-protocol runtime checks driven through the Rive MCP, cross-checked against the editor's built-in scripting reference.

--- a/docs/quick-reference.mdx
+++ b/docs/quick-reference.mdx
@@ -197,7 +197,7 @@ path:lineTo(Vector.xy(100, 100))
 path:close()
 ```
 
-If a path uses a fill, ensure the path is closed.
+If a path uses a fill, ensure the path is closed **and wound clockwise** (y points down) — counter-clockwise contours render invisible in the current renderer.
 
 ### Paint
 ```lua

--- a/docs/rive/protocols/node-protocol.mdx
+++ b/docs/rive/protocols/node-protocol.mdx
@@ -493,6 +493,10 @@ ANSWER: 2.00
 
 Procedural graphics in Rive use the <Term>Path</Term> API (moveTo, lineTo, close) combined with <Term>Paint</Term> for styling. Create these objects in init(), then use <Term>Renderer</Term>:drawPath() in draw().
 
+:::warning Wind your points clockwise
+The current Rive renderer fills **clockwise-wound** contours. If you connect the same three points counter-clockwise (top → bottom-left → bottom-right), the script compiles and runs but the triangle renders invisible. Order your points clockwise on screen — and remember that y points **down** in artboard coordinates. Editor-validated 2026-06-12 with side-by-side CW/CCW triangles; reported by community member belal-sweileh in [issue #2](https://github.com/ivg-design/lerp/issues/2).
+:::
+
 :::info Goal
 By the end of this exercise, you will be able to Complete the init function to create a triangle path (3 points) and a green fill paint. The draw function should render the path.
 :::
@@ -540,9 +544,10 @@ function init(self: DrawTriangle, context: Context): boolean
     self.path = nil  -- Replace with Path.new()
 
     -- TODO 2: Build a triangle using moveTo, lineTo, lineTo, close
+    -- Wind the points CLOCKWISE or the fill will not render (see note above):
     -- Point 1: (0, -40) - top
-    -- Point 2: (-40, 40) - bottom left
-    -- Point 3: (40, 40) - bottom right
+    -- Point 2: (40, 40) - bottom right
+    -- Point 3: (-40, 40) - bottom left
 
     -- TODO 3: Create a Paint with green fill color
     -- Use Paint.with({ style = "fill", color = Color.rgb(80, 200, 120) })

--- a/docs/rive/rive-doc-errata.mdx
+++ b/docs/rive/rive-doc-errata.mdx
@@ -39,6 +39,7 @@ Entries are ordered newest first (freshest updates at the top).
 
 | ID | Area | Status | Severity | Short finding |
 |---|---|---|---|---|
+| LERP-ERR-015 | Path winding / fill rule | resolved | high | Resolved in LERP on 2026-06-12 after a report from GitHub user [belal-sweileh](https://github.com/ivg-design/lerp/issues/2): Exercise 3's described point order wound the triangle counter-clockwise, which the current clockwise-fill renderer does not draw; exercise reordered and winding rule documented. |
 | LERP-ERR-011 | Node protocol | resolved | high | Resolved in LERP on 2026-06-12: `draw` was documented as required for add-menu listing; editor-validated that draw-less Node scripts list, place, and run. |
 | LERP-GAP-012 | Node advance semantics | resolved | high | Resolved in LERP on 2026-06-12: documented the playback-vs-design-mode advance model — `return false` unsubscribes from the playback advance loop only, `draw` is independent, design-mode settle passes always pass `seconds = 0` and ignore the return value. |
 | LERP-ERR-013 | Vector deprecated usage | resolved | low | Resolved in LERP on 2026-06-12: glossary and environment exercise still taught deprecated `vec:length()` style despite the core-types deprecation table; switched to static `Vector.*` calls. |
@@ -53,6 +54,37 @@ Entries are ordered newest first (freshest updates at the top).
 | LERP-GAP-003 | ViewModel context | resolved | medium | Resolved in LERP on 2026-04-26: `context:viewModel()` wording now describes immediate data-context behavior, with `context:rootViewModel()` explicitly documented for root/global state. |
 | LERP-ERR-002 | Path Effect / PathCommand | resolved | high | Resolved in LERP on 2026-04-26: Path Effect examples now use string command-name comparisons and clarify `CommandType` is not a guaranteed global table in editor scripts. |
 | LERP-ERR-001 | ListenerAction | resolved | high | Resolved in LERP on 2026-04-26: ListenerAction guidance now uses `performAction(self, listenerContext)` as preferred and marks `perform` legacy. |
+
+---
+
+## LERP-ERR-015 - Exercise 3 triangle wound counter-clockwise renders invisible
+
+Status: resolved in LERP 2026-06-12 (was confirmed)
+
+Severity: high
+
+Reported by:
+
+- GitHub user [belal-sweileh](https://github.com/ivg-design/lerp/issues/2) (issue #2, 2026-05-19)
+
+Affected local docs before fix:
+
+- `/Users/ivg/github/lerp/docs/rive/protocols/node-protocol.mdx` (Exercise 3 starter point order)
+- `/Users/ivg/github/lerp/docs/api/drawing.mdx` and `/Users/ivg/github/lerp/docs/quick-reference.mdx` (no winding guidance)
+
+Evidence:
+
+- Live editor validation (Rive Early Access, 2026-06-12) with a side-by-side probe (`FillRuleProbe`): the reporter's exact counter-clockwise triangle (top → bottom-left → bottom-right) rendered invisible while the clockwise twin rendered normally.
+- The Rive runtime ships a clockwise fill pipeline (`FillRule::clockwise`; see runtime shader/pipeline docs), consistent with the observed behavior.
+- The scripting API exposes no fill-rule control on `Path` or `Paint` (also answering the reporter's API question).
+
+Why this matters:
+
+A beginner following the exercise exactly as written gets a compiling, running script that draws nothing — with no error pointing at winding order.
+
+Fix implemented in LERP (2026-06-12):
+
+- Exercise 3 point order changed to clockwise; winding warnings added to the exercise premise, the Path API reference, and the quick reference.
 
 ---
 

--- a/static/.well-known/ai-feed.json
+++ b/static/.well-known/ai-feed.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generatedAt": "2026-06-12T09:44:17.229Z",
+  "generatedAt": "2026-06-12T10:16:02.456Z",
   "canonical": "https://forge.mograph.life/apps/lerp/",
   "site": {
     "name": "LERP",

--- a/static/ai-feed.json
+++ b/static/ai-feed.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generatedAt": "2026-06-12T09:44:17.229Z",
+  "generatedAt": "2026-06-12T10:16:02.456Z",
   "canonical": "https://forge.mograph.life/apps/lerp/",
   "site": {
     "name": "LERP",

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -1,5 +1,5 @@
 # LERP Full Knowledge Surface (llms-full)
-Generated: 2026-06-12T09:44:17.227Z
+Generated: 2026-06-12T10:16:02.455Z
 Canonical: https://forge.mograph.life/apps/lerp/
 Scope: Complete documentation route inventory with page metadata for AI retrieval and citation.
 


### PR DESCRIPTION
Fixes #2.

The Node Protocol Exercise 3 triangle was described in counter-clockwise point order, which the current clockwise-fill renderer does not draw — a learner following the exercise exactly gets a compiling script that renders nothing.

Validated live in the Rive Early Access editor (2026-06-12) with a side-by-side probe: the reporter's exact CCW triangle rendered invisible while the CW twin rendered normally. The runtime's clockwise fill pipeline (`FillRule::clockwise`) is consistent with the behavior, and the scripting API exposes no fill-rule control on `Path`/`Paint`.

- Exercise 3 point order corrected to clockwise + winding warning in the premise
- Winding guidance added to the Path API reference and quick reference
- Errata entry LERP-ERR-015 with the evidence trail
- Changelogs (docs + root mirror), regenerated AI artifacts; production build passes