### PR TITLE
docs: release LERP 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to the LERP (Luau Education for Rive Professionals) course a
 
 ---
 
+## [1.3.0] — 2026-08-14
+
+### Changed
+
+- **Runtime boundary refresh** — aligned the compatibility record to released
+  Web `2.40.0` backed by C++ `runtime-v0.1.271`; kept parser canary
+  `runtime-v0.1.272` separate.
+- **Retired `drawCanvas` migration** — active Node/Layout and shader guidance
+  now merges Canvas/GPUCanvas recording into `draw(self, renderer)`.
+- **Expanded Luau and lifecycle coverage** — added source-confirmed 3D math,
+  typed Font/Blob and Global ViewModel properties, scoped library assets,
+  partial GPU writes, lifecycle corrections, and explicit host/editor metadata
+  boundaries with Early Access tiers.
+- **Deterministic discovery feeds** — AI feed generation now honors
+  `SOURCE_DATE_EPOCH` and otherwise derives a stable timestamp from the newest
+  release heading, so required generation and production builds are
+  byte-identical when source content is unchanged.
+- **[Errata LERP-GAP-017](docs/rive/rive-doc-errata.mdx)** — recorded the
+  August 14 MCP-driven Rive Beta 0.8.5390 build 5377 validation: Vector/Mat4
+  math and buffer writes, Mat2D/Mat4 equality, typed ViewModel lookups, the
+  explicit `any` cast required for runtime-accepted Blob string/buffer/`nil`
+  writes, a successful ranged GPUBuffer write with both overflow rejections,
+  and the failed live `GPUTextureView.format` access. Context global-VM,
+  imported-library, broader GPU lifecycle, and released Web 2.40.0 behavior
+  remain unexecuted.
+- **[Errata LERP-ERR-018](docs/rive/rive-doc-errata.mdx)** — reconciled the
+  complete event surface to the live Editor reference and a clean analyzer
+  probe: current event type names, exact `PointerType`, the full three-way
+  gamepad payload/ListenerContext/Node callback contract, and explicit
+  historical labeling for older runtime `*Invocation` wrappers. The same probe
+  accepted `AudioSound:pause/resume/play`; event dispatch and audio calls remain
+  runtime-unexecuted.
+
+### Added
+
+- `learn_luau_rive_scripts/runtime-v0262-surface.luau` static/LSP reconciliation fixture.
+
+---
+
 ## [1.2.12] — 2026-06-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -256,13 +256,13 @@ This course is built using [Docusaurus](https://docusaurus.io/), a modern static
 ## Installation
 
 ```bash
-yarn
+npm install
 ```
 
 ## Local Development
 
 ```bash
-yarn start
+npm run start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
@@ -270,7 +270,7 @@ This command starts a local development server and opens up a browser window. Mo
 ## Build
 
 ```bash
-yarn build
+npm run build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.

--- a/docs/advanced/gpu-shaders.mdx
+++ b/docs/advanced/gpu-shaders.mdx
@@ -22,7 +22,7 @@ import Term from '@site/src/components/Term';
 
 :::info Prerequisites
 Before this section, complete:
-- [Node Lifecycle](/rive/protocols/node-lifecycle) - where `init`, `advance`, `drawCanvas`, and `draw` belong
+- [Node Lifecycle](/rive/protocols/node-lifecycle) - where `init`, `advance`, and merged `draw` work belong
 - [Drawing API](/advanced/drawing-api) - renderer state and image compositing
 - [Core Types](/api/core-types#mat4) - `Mat4` for 3D-style transforms
 - [Performance Optimization](/best-practices/performance) - allocation and hot-loop discipline
@@ -35,7 +35,7 @@ Shader scripting is a preview / rollout-dependent surface. Runtime support, edit
 GPU shaders give Rive scripts a low-level rendering path for custom materials, post-processing, image treatments, and 3D-style geometry. The workflow has two parts:
 
 1. A `.wgsl` shader asset in the Rive file.
-2. A Luau script that creates GPU resources, opens render passes in `drawCanvas`, and composites the result back into the normal Rive renderer in `draw`.
+2. A Luau script that creates GPU resources, opens render passes and composites the result in one merged `draw` callback.
 
 The shader does not automatically receive Rive vector shapes. It only sees the vertex buffers, uniform buffers, textures, samplers, and bind groups that your script provides.
 
@@ -75,7 +75,7 @@ The safest pattern is:
 2. Build descriptor arrays in helper functions with explicit return types.
 3. Call methods such as `pipeline:getBindGroupLayout(0)` on the local `pipeline`, not on `self.pipeline` while it is still `GPUPipeline?`.
 4. Assign the completed resources to `self` after the pipeline and bind groups exist.
-5. In `drawCanvas`, copy optional `self.*` resources into locals and return early when any required handle is missing.
+5. In `draw`, copy optional `self.*` resources into locals and return early when any required handle is missing.
 
 ```lua
 local function makeFullscreenQuadVertexLayout(): { VertexBufferLayout }
@@ -117,19 +117,18 @@ Shader scripts split GPU work and normal Rive drawing:
 | `init(self, context)` | Create the `GPUCanvas`, load shader assets, create buffers, create pipeline and bind groups |
 | `update(self)` | Rebuild resources when editor inputs change |
 | `advance(self, seconds)` | Update time, animation values, and dynamic uniform buffers |
-| `drawCanvas(self)` | Open GPU render passes and issue `GPURenderPass` draw calls |
-| `draw(self, renderer)` | Composite `gpuCanvas.image` with the normal `Renderer` |
+| `draw(self, renderer)` | Open GPU render passes, issue draw calls, and composite `gpuCanvas.image` with the normal `Renderer` |
 
 The important boundary:
 
 ```text
-GPU rendering:        drawCanvas()
-Normal compositing:   draw(renderer)
+GPU rendering + compositing: draw(renderer)
 Animation state:      advance(seconds)
 Resource setup:       init() / update() / resize()
 ```
 
-`beginRenderPass()` belongs in `drawCanvas`, not `draw`. `renderer:drawImage(...)` belongs in `draw`, after the GPU canvas has produced an image.
+`beginRenderPass()` and `renderer:drawImage(...)` belong in the same `draw`
+callback. Finish the pass before compositing the produced image.
 
 ---
 
@@ -245,7 +244,7 @@ function init(self: HelloTriangle, context: Context): boolean
     return true
 end
 
-function drawCanvas(self: HelloTriangle)
+local function renderGpu(self: HelloTriangle)
     local gpu = self.gpu
     local pipeline = self.pipeline
     local vbo = self.vbo
@@ -277,6 +276,8 @@ function draw(self: HelloTriangle, renderer: Renderer)
         return
     end
 
+    renderGpu(self)
+
     renderer:drawImage(gpu.image, imageSampler, "srcOver", 1)
 end
 
@@ -288,7 +289,6 @@ return function(): Node<HelloTriangle>
         pipeline = nil,
         vbo = nil,
         init = init,
-        drawCanvas = drawCanvas,
         draw = draw,
     }
 end
@@ -300,8 +300,8 @@ Why this works:
 - WGSL `@location(1)` matches `VertexAttribute.slot = 1`.
 - The pipeline color target uses the local `gpu.format`.
 - The render pass omits `view`, so the color attachment defaults to the canvas backing view.
-- `drawCanvas` uses local non-null resources and returns before rendering if any required resource is missing.
-- `draw` composites `GPUCanvas.image` with the normal renderer.
+- `renderGpu` uses local non-null resources and returns before rendering if any required resource is missing.
+- `draw` finishes GPU work before compositing `GPUCanvas.image` with the normal renderer.
 
 ---
 
@@ -537,7 +537,7 @@ The course shader examples are based on the corrected local example pack in `/Us
 
 | Example | What it teaches | Course role |
 |---------|-----------------|-------------|
-| `01_hello_gpu_canvas_triangle` | First `GPUCanvas`, typed vertex layout, pipeline, and `drawCanvas` pass | Starter template for new shader nodes |
+| `01_hello_gpu_canvas_triangle` | First `GPUCanvas`, typed vertex layout, pipeline, and merged `draw` pass | Starter template for new shader nodes |
 | `02_animated_gradient_quad` | Uniform buffer updates from `advance` | First animated shader |
 | `03_uv_checkerboard` | UV debugging and fullscreen quad coordinates | Debugging texture-space mistakes |
 | `04_image_texture_tint` | `context:image(name)`, `Image:view()`, texture binding, and tint uniforms | First image sampling lab |
@@ -558,7 +558,7 @@ Work through the guided version in [GPU Shader Example Labs](/projects/gpu-shade
 |---------|-------|
 | `context:shader(name)` returns `nil` | Asset name without `.wgsl`, shader asset packaging, shader compile status, editor channel, runtime channel |
 | `colorView()` errors | Deferred canvas has not been resized |
-| Nothing appears | `drawCanvas` is returned from the factory, `pass:finish()` is called, and `draw` composites `gpuCanvas.image` |
+| Nothing appears | GPU work and `pass:finish()` are inside `draw`, which then composites `gpuCanvas.image` |
 | Wrong colors or broken geometry | WGSL `@location` values match vertex layout `slot` and `offset` |
 | Bind group errors | WGSL `@group` / `@binding` values match `GPUBindGroup` entries |
 | Luau rejects nested descriptor tables | Move `attributes`, `vertexLayout`, `colorTargets`, `ubos`, `textures`, and `samplers` into explicitly typed locals |
@@ -805,10 +805,9 @@ Complete the four TODOs and run the script.
   options={[
     { text: "init" },
     { text: "advance" },
-    { text: "drawCanvas", correct: true },
-    { text: "draw" },
+    { text: "draw", correct: true },
   ]}
-  explanation="GPU render passes belong in drawCanvas. The normal draw callback is for compositing the resulting image with the Renderer."
+  explanation="GPU render passes and compositing belong in the merged draw callback; finish the pass before drawing its image with the Renderer."
 />
 
 <Quiz

--- a/docs/advanced/viewmodels.mdx
+++ b/docs/advanced/viewmodels.mdx
@@ -1010,6 +1010,39 @@ ANSWER: nested
 
 ---
 
+## Global models and asset-valued data
+
+`context:globalViewModel(name)` and `context:globalViewModelNames()` expose
+only ViewModels declared global in the file. Unknown names return `nil`; keep
+the name explicit because global access increases coupling between components.
+Use `context:viewModel()` for the immediate context and
+`context:rootViewModel()` for the root model.
+
+```lua
+function init(self: SharedState, context: Context): boolean
+    local names = context:globalViewModelNames()
+    self.global = context:globalViewModel("Theme")
+    if not self.global then
+        return false
+    end
+    return #names > 0
+end
+```
+
+The target source also supports `getFont` and `getBlob`. A detached instance
+created with `viewModel:instance()` advances at frame end when owned by a
+scripted wrapper, so trigger/listener state can reset on the next frame. Do
+not rely on detached triggers staying latched. A property-valued Font is
+opaque and cannot be cleared with `nil` from Luau; Blob properties accept Blob
+userdata, buffers, strings, and `nil`, with empty payloads distinct from nil.
+The current editor type checker requires an explicit `property :: any` cast
+for the buffer/string/nil setter forms.
+
+These additions are source-confirmed in the v0.1.262 impact snapshot. Rive
+Beta 0.8.5390 (build 5377) independently passed the typed property and Blob
+runtime checks, but the released Web lane remains unprobed; keep this
+compatibility-preview material until that lane is verified.
+
 ## Knowledge Check
 
 <Quiz

--- a/docs/api/assets.mdx
+++ b/docs/api/assets.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 6
 title: Assets
-description: Image, ImageFilter, ImageSampler, and ImageWrap
+description: Image, Blob, AudioSource, AudioSound, sampling, and Early Access GPU texture-view boundaries
 keywords:
   - rive
   - luau
@@ -11,6 +11,10 @@ keywords:
   - assets
   - image
   - imagefilter
+  - blob
+  - audio
+  - audiosound
+  - gputextureview
 ---
 import Term from '@site/src/components/Term';
 
@@ -59,6 +63,22 @@ textures = {{ slot = 1, view = image:view() }}
 ```
 
 **See Also:** [<Term>Renderer</Term>.drawImage](./drawing#rendererdrawimageimage-sampler-blendmode-opacity), [GPU Shaders](./gpu-shaders#image-color-and-buffer-utilities)
+
+### `GPUTextureView.format`
+
+The pinned runtime source declares a texture-view format field, but the August
+14 Rive Beta MCP probe could not read it:
+
+```lua
+local texture = GPUTexture.new({ width = 64, height = 64, renderTarget = true })
+local view = texture:view()
+print(view.format) -- Live failure: attempt to index userdata with 'format'
+```
+
+Treat this as source-only Early Access material, not a working Editor property.
+The same live build executed GPU constructors and ranged `GPUBuffer` writes
+despite reporting the GPU constructor globals as unknown in the analyzer; that
+analyzer/runtime mismatch does not make `format` usable.
 
 ---
 
@@ -120,7 +140,9 @@ Defines how texture coordinates outside the [0, 1] range are handled.
 
 ## Blob
 
-Binary data asset accessed via `context:blob(name)`.
+Binary data can arrive either as an asset lookup or as a data-bound property.
+These are separate APIs: `context:blob(name)` resolves a packaged asset, while
+`viewModel:getBlob(name)` returns a mutable `Property<Blob>`.
 
 ### Attributes
 
@@ -130,7 +152,12 @@ Binary data asset accessed via `context:blob(name)`.
 | `size` | number | Data size in bytes (read-only) |
 | `data` | buffer | Raw binary data (read-only) |
 
-**See Also:** [Context](./data-input#context)
+**See Also:** [Context](./data-input#context), [Property&lt;Blob&gt;](./data-values#propertyblob)
+
+An empty string or empty buffer assigned to a `Property<Blob>` creates a real
+zero-byte Blob. Assigning `nil` clears the property. Repeated reads of an
+unchanged asset-valued property preserve wrapper identity; a replacement
+invalidates the cached wrapper.
 
 ---
 
@@ -208,6 +235,34 @@ Stops playback.
 ```lua
 sound:stop()
 ```
+
+#### `sound:pause()`
+
+Pauses playback.
+
+```lua
+sound:pause()
+```
+
+#### `sound:resume()`
+
+Resumes paused playback.
+
+```lua
+sound:resume()
+```
+
+#### `sound:play()`
+
+Starts or restarts playback for this sound instance.
+
+```lua
+sound:play()
+```
+
+The current Editor reference and analyzer accept these three transport
+methods. The August 14 probe did not execute the calls, so this is static
+Editor evidence rather than runtime playback evidence.
 
 #### `sound:seek(seconds)`
 

--- a/docs/api/core-types.mdx
+++ b/docs/api/core-types.mdx
@@ -23,7 +23,7 @@ Essential data types for positions, colors, and 2D/3D transformations.
 
 ## Vector
 
-2D vector type for positions, directions, and sizes. Vector components are **read-only** and operations return new vectors.
+Vector type for positions, directions, and sizes. `Vector.xy` creates a 2D vector; the runtime also supports a z component for 3D math. Components are **read-only** and operations return new vectors.
 
 > **Note:** Some examples may show `Vec2D` which is an alias for `Vector`.
 
@@ -50,6 +50,22 @@ Vector.xy(x: number, y: number): Vector
 local position = Vector.xy(100, 50)
 local direction = Vector.xy(1, 0)  -- Unit vector pointing right
 ```
+
+#### `Vector.xyz(x, y, z)`
+
+Creates a vector with an explicit z component. This is a runtime-v0.1.262
+source-level API; verify the selected editor and published Web runtime before
+using it in a production course exercise.
+
+```lua
+Vector.xyz(x: number, y: number, z: number): Vector
+
+local normal = Vector.xyz(0, 0, 1)
+```
+
+Focused validation in Rive Beta 0.8.5390 (build 5377) passed `Vector.xyz`,
+`Vector.cross3`, and vector buffer writes. This confirms the selected editor
+lane only; it does not establish availability in released Web 2.40.0.
 
 #### `Vector.origin()`
 
@@ -173,6 +189,37 @@ local c = Vector.cross(Vector.xy(1, 0), Vector.xy(0, 1))  -- 1
 ```
 
 **When to use:** Determining winding order (clockwise vs counter-clockwise), computing signed areas, checking which side of a line a point is on.
+
+#### `Vector.cross3(a, b)`
+
+Returns the 3D vector cross product. Do not substitute this for `Vector.cross`:
+`cross` returns the scalar z-component used by 2D winding/math, while `cross3`
+returns a `Vector`.
+
+```lua
+Vector.cross3(a: Vector, b: Vector): Vector
+
+local normal = Vector.cross3(Vector.xyz(1, 0, 0), Vector.xyz(0, 1, 0))
+-- Vector(0, 0, 1)
+```
+
+#### Buffer writes
+
+The target runtime can write vector components as `float32` values.
+`writeToBuffer` writes 12 bytes (`x`, `y`, `z`) and `writeVec4` writes 16
+bytes (`x`, `y`, `z`, `w`). Both validate destination bounds.
+
+```lua
+vector:writeToBuffer(destination: buffer, byteOffset: number): ()
+vector:writeVec4(destination: buffer, byteOffset: number, w: number): ()
+
+local bytes = buffer.create(32)
+Vector.xyz(1, 2, 3):writeToBuffer(bytes, 4) -- bytes 4..15
+Vector.xyz(1, 2, 3):writeVec4(bytes, 16, 1) -- bytes 16..31
+```
+
+Writing past the destination reports an error rather than silently truncating;
+cover both valid layouts and negative bounds cases in shader tests.
 
 #### `Vector.scaleAndAdd(a, b, scale)`
 
@@ -557,6 +604,9 @@ local combined = mat1 * mat2  -- Apply mat2 first, then mat1
 
 Returns true if all components are equal.
 
+The August 14 Rive Beta MCP runtime probe confirmed this operator: two identity
+`Mat2D` values compared equal and an identity/translated pair compared unequal.
+
 ```lua
 if mat1 == mat2 then
     print("Same transform")
@@ -602,6 +652,8 @@ Mat4.fromRotationY(radians: number): Mat4
 Mat4.fromRotationZ(radians: number): Mat4
 Mat4.perspective(fovY: number, aspect: number, near: number, far: number): Mat4
 Mat4.perspectiveReverseZ(fovY: number, aspect: number, near: number): Mat4
+Mat4.lookAt(eye: Vector, center: Vector, up: Vector): Mat4
+Mat4.ortho(left: number, right: number, bottom: number, top: number, near: number, far: number): Mat4
 Mat4.multiply(out: Mat4, a: Mat4, b: Mat4): Mat4
 Mat4.multiplyAffine(out: Mat4, a: Mat4, b: Mat4): Mat4
 Mat4.invert(out: Mat4, input: Mat4): boolean
@@ -628,6 +680,10 @@ Mat4 * Mat4 -> Mat4
 matA == matB -> boolean
 ```
 
+The August 14 Rive Beta MCP runtime probe confirmed `Mat4` equality: two
+identity matrices compared equal and an identity/translated pair compared
+unequal.
+
 ### Example
 
 ```lua
@@ -653,6 +709,18 @@ self.cameraBuffer:write(bytes, 0)
 ```
 
 For reverse-Z depth, use `Mat4.perspectiveReverseZ(...)`, clear depth to `0.0`, and use depth compare `"greater"`.
+
+`Mat4.lookAt` creates a right-handed view matrix. `Mat4.ortho` creates a
+right-handed orthographic projection with depth mapped to `[0, 1]`. These are
+math helpers for scripted rendering; they do not make the general Rive scene
+graph a 3D scene.
+
+```lua
+local eye = Vector.xyz(0, 0, 4)
+local view = Mat4.lookAt(eye, Vector.xyz(0, 0, 0), Vector.xyz(0, 1, 0))
+local projection = Mat4.ortho(-2, 2, -2, 2, 0.1, 100)
+local viewProjection = projection * view
+```
 
 ## Next Steps
 

--- a/docs/api/data-input.mdx
+++ b/docs/api/data-input.mdx
@@ -466,6 +466,21 @@ Gets the root ViewModel of the artboard data hierarchy.
 context:rootViewModel(): ViewModel?
 ```
 
+#### `context:globalViewModel(name)`
+
+Gets a file-global ViewModel by its declared name. Only models explicitly
+declared global resolve; an unknown or non-global name returns `nil`.
+
+```lua
+context:globalViewModel(name: string): ViewModel?
+context:globalViewModelNames(): {string}
+```
+
+Names are returned as a 1-based Luau array. With no file attached the names
+array is allocated but empty. Global-model access is source-confirmed in
+runtime-v0.1.262 and should remain a compatibility-preview lesson until the
+editor and selected Web package are independently verified.
+
 #### `context:dataContext()`
 
 Gets the DataContext for hierarchy traversal.
@@ -597,6 +612,13 @@ The following constructors and object APIs are runtime-bound and documented upst
 - `GPUTextureView.format`
 - `Image:view()` for sampling an image asset as a shader texture
 
+Live Editor evidence is mixed. A ranged `GPUBuffer:write` succeeded and both
+overflow cases were rejected, even though the analyzer called the GPU
+constructor globals unknown. `GPUTextureView.format` then failed at runtime
+with `attempt to index userdata with 'format'`. Keep the whole family Early
+Access; do not infer GPUCanvas/render-pass/shader-lifecycle coverage from the
+single buffer probe.
+
 For course-stability policy, see [Runtime Compatibility Baseline](/rive/runtime-compatibility).
 
 #### `context:markNeedsUpdate()`
@@ -616,7 +638,9 @@ context:markNeedsUpdate()
 Connects editor elements to data and code. Provides access to bound properties by type.
 
 :::warning Runtime baseline note
-At the current compatibility baseline (public npm runtime line `2.37.8`, source-level API snapshot `runtime-v0.1.106`, revalidated June 4, 2026), `viewModel.name` is documented upstream but not exposed in the C++ Luau bindings.
+At the accepted released compatibility boundary (`@rive-app/*@2.40.0`, C++
+`runtime-v0.1.271`), `viewModel.name` remains a documentation/source distinction
+that is not a callable Luau field in the checked binding surface.
 Use explicit property lookups (`getNumber`, `getString`, etc.) instead of relying on a `name` field.
 :::
 
@@ -677,6 +701,21 @@ Gets an image property by name.
 ```lua
 viewModel:getImage(name: string): Property<Image>?
 ```
+
+#### `viewModel:getFont(name)` and `viewModel:getBlob(name)`
+
+Typed asset-valued properties are nullable when the named property is absent:
+
+```lua
+viewModel:getFont(name: string): Property<Font>?
+viewModel:getBlob(name: string): Property<Blob>?
+```
+
+`Property<Font>.value` reads a `Font?` but the Luau setter requires a `Font`;
+host-side null clearing is a native integration operation. The Blob runtime
+setter accepts Blob userdata, a buffer, a string, or `nil`; in the current
+editor type checker, use an explicit `property :: any` cast for the latter
+three forms. Empty payloads remain real zero-byte Blobs. See [Data Values](./data-values#asset-valued-properties).
 
 #### `viewModel:getViewModel(name)`
 

--- a/docs/api/data-values.mdx
+++ b/docs/api/data-values.mdx
@@ -169,6 +169,60 @@ dv.alpha = 255
 
 **See Also:** [DataValue](#datavalue), [Color](./core-types#color)
 
+## Asset-valued properties
+
+ViewModel properties can carry opaque asset values in the target runtime.
+These are distinct from strings, buffers, and editor asset IDs.
+
+### `Property<Font>`
+
+`Property<Font>` reads an opaque `Font` userdata or `nil`:
+
+```lua
+local fontProperty: Property<Font>? = viewModel:getFont("font")
+if fontProperty then
+    local font = fontProperty.value
+    if font then
+        textStyle.fontAssetId = font
+    end
+end
+```
+
+The Luau setter accepts another `Font` userdata. It does not accept a string,
+buffer, or `nil`; a native host may clear the value with a null font. Keep the
+property handle alive when registering listeners.
+
+### `Property<Blob>`
+
+`Property<Blob>` reads a `Blob?`; the runtime accepts a Blob, buffer, string, or
+`nil`. In the current editor type checker, use an explicit `any` cast for
+these writable input forms:
+
+```lua
+local payload: Property<Blob>? = viewModel:getBlob("payload")
+if payload then
+    local writable = payload :: any
+    writable.value = buffer.fromstring("hello")
+    writable.value = "raw bytes"
+    local blob = payload.value
+    if blob and blob.data then
+        print(blob.name, blob.size, buffer.readu8(blob.data, 0))
+    end
+    writable.value = nil -- clear the bound value
+end
+```
+
+Without that cast, the editor reports `Expected this to be Blob` for string,
+buffer, and `nil` assignments even though the runtime accepts them. A focused
+Rive Beta 0.8.5390 (build 5377) probe passed `getBlob`, `getFont`,
+`getImage`, missing/null handling, and all three Blob assignment forms after
+the explicit cast. This is editor-lane evidence, not released Web 2.40.0
+compatibility proof.
+
+An empty string or empty buffer is a real zero-byte Blob, not `nil`. The
+`Blob.name`, `Blob.size`, and `Blob.data` fields are the data-access surface;
+there are no implied Blob mutation methods.
+
 ---
 
 ## Converter

--- a/docs/api/events.mdx
+++ b/docs/api/events.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
 title: Events
-description: PointerEvent plus ListenerContext payload invocations for listener-driven scripts
+description: Current Editor event types, ListenerContext payloads, and Node gamepad callbacks
 keywords:
   - rive
   - luau
@@ -22,7 +22,17 @@ import Quiz from '@site/src/components/Quiz';
 APIs for pointer interactions and listener-trigger payloads.
 
 :::info Runtime baseline
-This page reflects the June 4, 2026 compatibility baseline: public npm runtime line `2.37.8`, with source pins tracked in [Runtime Compatibility Baseline](/rive/runtime-compatibility).
+This page reflects the released Web `2.40.0` -> C++ `runtime-v0.1.271` boundary, with source pins tracked in [Runtime Compatibility Baseline](/rive/runtime-compatibility).
+:::
+
+:::note August 14 Editor reference validation
+The names and signatures below were revalidated through the Rive MCP against
+the built-in `rive/artboards` and `rive/interfaces` references in Rive Beta
+0.8.5390 build 5377. A temporary Tests script covering the complete surface
+recompiled with diagnostics `[]`; the original three runtime cases still
+passed after the probe was removed. This proves Editor analyzer acceptance, not
+hardware gamepad dispatch or the released Web runtime path. Those evidence
+tiers remain separate in the compatibility page.
 :::
 
 ---
@@ -30,6 +40,26 @@ This page reflects the June 4, 2026 compatibility baseline: public npm runtime l
 ## PointerEvent
 
 Pointer interaction event data.
+
+### `PointerType`
+
+The current Editor reference types `PointerEvent.type` with this string union:
+
+```lua
+export type PointerType =
+    "pointerEnter"
+    | "pointerExit"
+    | "pointerDown"
+    | "pointerUp"
+    | "pointerMove"
+    | "click"
+    | "pointerDrag"
+    | "unknown"
+```
+
+The upstream reference still labels the standalone alias "Coming soon," even
+though the current Editor reference exposes it and uses it for
+`PointerEvent.type`. It is a type alias, not a runtime enum table.
 
 ### Constructor
 
@@ -54,9 +84,7 @@ local childEvent = PointerEvent.new(event.id, childPos)
 |-----------|------|-------------|
 | `position` | Vector | Local coordinates |
 | `id` | number | Pointer ID (for multitouch) |
-| `type` | string | Event type (`pointerDown`, `pointerUp`, `pointerMove`, `pointerExit`, `pointerEnter`, `click`, `pointerDrag`, `unknown`) |
-| `previousPosition` | Vector | Previous pointer position (when available) |
-| `timeStamp` | number | Event timestamp (seconds) |
+| `type` | `PointerType` | Current event-kind string |
 
 ### Methods
 
@@ -99,19 +127,23 @@ end
 - `listenerContext:isFocus()`
 - `listenerContext:isReportedEvent()`
 - `listenerContext:isViewModelChange()`
-- `listenerContext:isGamepad()`
+- `listenerContext:isGamepadConnected()`
+- `listenerContext:isGamepadEvent()`
+- `listenerContext:isGamepadDisconnected()`
 - `listenerContext:isNone()`
 
 ### Typed Accessors
 
 - `listenerContext:asPointerEvent(): PointerEvent?`
-- `listenerContext:asKeyboardEvent(): KeyboardInvocation?`
-- `listenerContext:asTextInput(): TextInputInvocation?`
-- `listenerContext:asFocus(): FocusInvocation?`
-- `listenerContext:asReportedEvent(): ReportedEventInvocation?`
-- `listenerContext:asViewModelChange(): ViewModelChangeInvocation?`
-- `listenerContext:asGamepad(): GamepadInvocation?`
-- `listenerContext:asNone(): NoneInvocation?`
+- `listenerContext:asKeyboardEvent(): KeyboardEvent?`
+- `listenerContext:asTextInput(): TextInput?`
+- `listenerContext:asFocus(): FocusEvent?`
+- `listenerContext:asReportedEvent(): ReportedEvent?`
+- `listenerContext:asViewModelChange(): ViewModelChange?`
+- `listenerContext:asGamepadConnected(): GamepadConnected?`
+- `listenerContext:asGamepadEvent(): GamepadEvent?`
+- `listenerContext:asGamepadDisconnected(): GamepadDisconnected?`
+- `listenerContext:asNone(): NoneEvent?`
 
 ### Safe Branching Example
 
@@ -132,10 +164,10 @@ function performAction(self: MyAction, listenerContext: ListenerContext)
         if evt then
             print("text:", evt.text)
         end
-    elseif listenerContext:isGamepad() then
-        local evt = listenerContext:asGamepad()
+    elseif listenerContext:isGamepadEvent() then
+        local evt = listenerContext:asGamepadEvent()
         if evt then
-            print("gamepad:", evt.deviceId, evt.buttonMask, evt.axis0)
+            print("gamepad change:", evt.changeKind, evt.changeIndex, evt.changeValue)
         end
     end
 end
@@ -143,9 +175,13 @@ end
 
 ---
 
-## KeyboardInvocation
+## KeyboardEvent
 
 Keyboard payload exposed via `listenerContext:asKeyboardEvent()`.
+
+```lua
+export type KeyPhase = "down" | "repeat" | "up"
+```
 
 | Field | Type | Description |
 |---|---|---|
@@ -154,11 +190,11 @@ Keyboard payload exposed via `listenerContext:asKeyboardEvent()`.
 | `control` | boolean | Control modifier active |
 | `alt` | boolean | Alt modifier active |
 | `meta` | boolean | Meta/Command modifier active |
-| `phase` | `"down" \| "repeat" \| "up"` | Key phase |
+| `phase` | `KeyPhase` | `"down"`, `"repeat"`, or `"up"` |
 
 ---
 
-## TextInputInvocation
+## TextInput
 
 Text input payload exposed via `listenerContext:asTextInput()`.
 
@@ -168,7 +204,7 @@ Text input payload exposed via `listenerContext:asTextInput()`.
 
 ---
 
-## FocusInvocation
+## FocusEvent
 
 Focus payload exposed via `listenerContext:asFocus()`.
 
@@ -178,39 +214,122 @@ Focus payload exposed via `listenerContext:asFocus()`.
 
 ---
 
-## ReportedEventInvocation
+## ReportedEvent
 
-`listenerContext:asReportedEvent()` is available, but payload exposure is currently limited in this runtime baseline.
-
-- Confirmed field: `delaySeconds`
-- Treat additional reported-event fields as compatibility-sensitive until validated in a newer baseline.
-
----
-
-## ViewModelChangeInvocation
-
-`listenerContext:asViewModelChange()` is available, but payload detail is currently minimal in this baseline (type presence + branching support).
+`listenerContext:asReportedEvent()` returns `ReportedEvent?`. The current Editor
+reference declares no public fields on this type, so current-facing examples
+must treat it as a presence/kind signal only.
 
 ---
 
-## GamepadInvocation
+## ViewModelChange
 
-Gamepad payload exposed via `listenerContext:asGamepad()`.
+`listenerContext:asViewModelChange()` returns `ViewModelChange?`. The current
+Editor reference declares no public fields on this type.
+
+---
+
+## Gamepad Events
+
+Gamepad listener payloads are three distinct types. Do not collapse them into a
+generic `GamepadInvocation`.
+
+```lua
+export type GamepadMappingKind = "standard" | "unknown"
+```
+
+### `GamepadConnected`
+
+Access with `isGamepadConnected()` and `asGamepadConnected()`.
 
 | Field | Type | Description |
 |---|---|---|
-| `deviceId` | number | Runtime gamepad device ID |
-| `buttonMask` | number | Bitmask of pressed buttons |
-| `axis0` | number | Primary analog axis value |
+| `deviceId` | number | Stable device ID for the logical gamepad session |
+| `buttonMask` | number | Pressed-button bitmask |
+| `buttons` | `{ number }` | 1-based analog button values |
+| `axes` | `{ number }` | 1-based analog axes |
+| `isStandardMapping` | boolean | Whether the embedder normalized the standard layout |
+| `mapping` | `GamepadMappingKind` | `"standard"` or `"unknown"` |
+| `gamepadMapping` | number | Raw mapping enum value (`0` standard, `1` unknown) |
+| `west`, `south`, `north`, `east` | boolean | Standard face-button state |
+| `leftShoulder`, `rightShoulder` | boolean | Shoulder-button state |
+| `back`, `forward`, `start` | boolean | Standard navigation/start-button state |
+| `leftStickButton`, `rightStickButton` | boolean | Stick-click state |
+| `dpadUp`, `dpadDown`, `dpadLeft`, `dpadRight` | boolean | Direction-pad state |
+| `leftStick`, `rightStick` | Vector | Analog stick vectors |
+| `leftTrigger`, `rightTrigger` | number | Analog trigger values |
+| `leftTriggerPressed`, `rightTriggerPressed` | boolean | Digital trigger-button state |
+
+Methods:
+
+- `event:buttonPressed(index: number): boolean`
+- `event:buttonValue(index: number): number`
+- `event:axis(index: number): number`
+
+The current reference documents these indices as 1-based.
+
+### `GamepadEvent`
+
+Access with `isGamepadEvent()` and `asGamepadEvent()`. It contains the same full
+device-state fields and query methods as `GamepadConnected`, plus:
+
+| Field | Type | Description |
+|---|---|---|
+| `changeKind` | string | `"button"` or `"axis"` |
+| `changeIndex` | number | 1-based button or axis index |
+| `changeValue` | number | New analog value |
+| `hasStandardButtonIntent` | boolean | Whether a standard button intent exists |
+| `hasStandardAxisIntent` | boolean | Whether a standard axis intent exists |
+| `intentButton` | string? | Optional semantic button intent |
+| `intentAxis` | string? | Optional semantic axis intent |
+
+### `GamepadDisconnected`
+
+Access with `isGamepadDisconnected()` and `asGamepadDisconnected()`. It exposes
+only `deviceId: number`.
+
+### Node Gamepad Callbacks
+
+The current Editor `Node<T>` reference exposes these optional callbacks:
+
+```lua
+function gamepadConnected(self: MyNode, event: GamepadConnected)
+    print("connected", event.deviceId, event.mapping)
+end
+
+function gamepadEvent(self: MyNode, event: GamepadEvent)
+    print(event.changeKind, event.changeIndex, event.changeValue)
+end
+
+function gamepadDisconnected(self: MyNode, event: GamepadDisconnected)
+    print("disconnected", event.deviceId)
+end
+```
 
 ---
 
-## NoneInvocation
+## NoneEvent
 
-Fallback event shape for unsupported/unknown listener invocations.
+Fallback event shape for unknown or unsupported listener event kinds. The
+current Editor reference declares no public fields.
 
 - Check with `listenerContext:isNone()`
 - Access with `listenerContext:asNone()`
+
+---
+
+## Historical Runtime Wrapper Names
+
+The pinned `runtime-v0.1.262` source snapshot still uses Lua userdata wrapper
+names such as `KeyboardInvocation`, `TextInputInvocation`, `FocusInvocation`,
+`ReportedEventInvocation`, `ViewModelChangeInvocation`, and `NoneInvocation`.
+It also exposes `delaySeconds` on that historical reported-event wrapper. These
+names explain older source and LERP material; they are not the type names in the
+current Editor reference and should not be used for new Editor-authored code.
+
+The generic `GamepadInvocation` / `isGamepad()` / `asGamepad()` shape previously
+shown by LERP is not the current reference contract. Current gamepad code must
+use the connected/event/disconnected triad above.
 
 ---
 
@@ -229,19 +348,19 @@ See [Data & Input: Trigger](./data-input#inputtrigger) for the `Trigger` type re
     { text: "Use perform(self, pointerEvent) only, even for keyboard/text listeners." },
     { text: "ListenerAction events always contain keyboard fields." },
   ]}
-  explanation="ListenerContext is a tagged union. Use is... guards first, then the matching as... accessor. This applies to pointer, keyboard, text, focus, reported, gamepad, and none invocations."
+  explanation="ListenerContext is a tagged union. Use is... guards first, then the matching as... accessor. Gamepad payloads have separate connected, event, and disconnected branches."
 />
 
 <Quiz
-  question="Which GamepadInvocation field is currently exposed in ListenerContext payloads?"
+  question="Which guard reads a changed gamepad button or axis payload?"
   id="api-events-q2"
   options={[
-    { text: "thumbstickY" },
-    { text: "buttonMask", correct: true },
-    { text: "vendorName" },
-    { text: "batteryPercent" },
+    { text: "isGamepad()" },
+    { text: "isGamepadConnected()" },
+    { text: "isGamepadEvent()", correct: true },
+    { text: "isGamepadDisconnected()" },
   ]}
-  explanation="At this runtime baseline, GamepadInvocation exposes `deviceId`, `buttonMask`, and `axis0`."
+  explanation="Use isGamepadEvent(), then asGamepadEvent(), for a button or axis change. Connection and disconnection are separate payload kinds."
 />
 
 ## Next Steps

--- a/docs/api/gpu-shaders.mdx
+++ b/docs/api/gpu-shaders.mdx
@@ -96,7 +96,7 @@ local samplers: { SamplerEntry } = {
 }
 ```
 
-Create GPU resources in non-null locals inside `init`, call methods on those locals, then assign them to optional `self.*` fields after setup succeeds. In `drawCanvas`, localize optional fields and return before issuing render work if any required handle is missing.
+Create GPU resources in non-null locals inside `init`, call methods on those locals, then assign them to optional `self.*` fields after setup succeeds. In `draw`, localize optional fields and return before issuing render work if any required handle is missing.
 
 ---
 
@@ -147,6 +147,14 @@ elseif features.maxSamples >= 2 then
     sampleCount = 2
 end
 ```
+
+In the current Early Access source path, `context:features()` can fail when a
+deferred recorder has no replay device yet. Query it from a render-time method
+after a device/first frame is available, not at module scope. Size-less
+`canvas()` and `gpuCanvas()` handles may exist before allocation; dimensions can
+remain pending until a device is attached. A resize to the current size is a
+no-op. Treat these as lifecycle constraints, not guarantees of editor/Web
+availability.
 
 ### `context:shader(name)`
 
@@ -227,7 +235,7 @@ declare extern type Canvas with
 end
 ```
 
-Use `beginFrame` / `endFrame` inside `drawCanvas`.
+Use `beginFrame` / `endFrame` inside `draw`.
 
 ### GPUCanvas
 
@@ -252,7 +260,7 @@ end
 | `format` | Pixel format of the backing texture; use for pipeline color targets |
 | `resize(w, h)` | Recreates the backing texture |
 | `colorView()` | Returns a `GPUTextureView` for the backing texture |
-| `beginRenderPass(desc)` | Opens a render pass; call inside `drawCanvas` |
+| `beginRenderPass(desc)` | Opens a render pass; call inside `draw` |
 
 ---
 
@@ -355,7 +363,7 @@ GPU memory for vertices, indices, or uniforms.
 ```lua
 declare extern type GPUBuffer with
     size: number
-    function write(self, data: buffer, offset: number?): ()
+    function write(self, data: buffer, destinationOffset: number?, sourceOffset: number?, byteLength: number?): ()
 end
 
 declare GPUBuffer: {
@@ -400,6 +408,14 @@ buffer.writef32(self.uniformBytes, 0, self.time)
 buffer.writef32(self.uniformBytes, 4, self.strength)
 self.uniformBuffer:write(self.uniformBytes, 0)
 ```
+
+The optional `sourceOffset` and `byteLength` arguments permit partial uploads:
+`write(source, destinationOffset?, sourceOffset?, byteLength?)`. The runtime
+validates both source and destination ranges. In the August 14 Rive Beta MCP
+probe, a valid ranged write succeeded and both source- and destination-overflow
+cases were rejected. The Editor analyzer still reported `GPUBuffer` as an
+unknown global, so this remains a narrow runtime pass inside an Early Access
+surface rather than a broadly authorable GPU workflow.
 
 ---
 
@@ -474,7 +490,12 @@ declare extern type GPUTextureView with
 end
 ```
 
-Use a texture view as a render attachment, MSAA resolve target, depth/stencil attachment, shader texture binding, or `Image:view()` result.
+Use a texture view as a render attachment, MSAA resolve target, depth/stencil
+attachment, shader texture binding, or `Image:view()` result. The `format`
+field exists in the pinned source declaration, but live access in Rive Beta
+0.8.5390 build 5377 failed with
+`attempt to index userdata with 'format'`. Treat it as source-only Early Access
+material until an Editor/runtime probe succeeds.
 
 ---
 
@@ -1021,7 +1042,7 @@ The GPU API does not provide a full scene graph, material system, lighting syste
 |---------|------------|
 | `context:shader(name)` returns `nil` | Check asset name without `.wgsl`, shader compile status, shader packaging, and editor/runtime channel |
 | `colorView()` throws | Resize deferred `GPUCanvas` before rendering |
-| Nothing renders | Return `drawCanvas` from the factory, call `pass:finish()`, and composite `gpuCanvas.image` in `draw` |
+| Nothing renders | Keep GPU work and `pass:finish()` inside `draw`, then composite `gpuCanvas.image` |
 | Interleaved attributes read wrong | Verify every byte `offset` and `stride` |
 | Bind group mismatch | Match `@group` and `@binding` to bind group index and `slot` |
 | Luau rejects `vertexLayout`, `colorTargets`, `ubos`, `textures`, or `samplers` | Move nested descriptors into explicitly typed locals such as `{ VertexAttribute }`, `{ VertexBufferLayout }`, `{ ColorTarget }`, `{ UBOEntry }`, `{ TextureEntry }`, and `{ SamplerEntry }` |

--- a/docs/api/hierarchy.mdx
+++ b/docs/api/hierarchy.mdx
@@ -19,7 +19,7 @@ import Term from '@site/src/components/Term';
 <Term>Node</Term> data access and layout scripting.
 
 :::info Runtime baseline
-`NodeReadData.paint`, `node:asPath()`, and `node:asPaint()` remain tracked as live in the June 4, 2026 compatibility baseline. See [Runtime Compatibility Baseline](/rive/runtime-compatibility) for the current npm line and source pins.
+`NodeReadData.paint`, `node:asPath()`, and `node:asPaint()` remain tracked as live in the August 14, 2026 compatibility baseline. See [Runtime Compatibility Baseline](/rive/runtime-compatibility) for the released Web line and source pins.
 See [Runtime Compatibility Baseline](/rive/runtime-compatibility) for tracked status.
 :::
 

--- a/docs/api/interpolation.mdx
+++ b/docs/api/interpolation.mdx
@@ -17,7 +17,7 @@ keywords:
 Runtime API surface for scripted interpolation.
 
 :::info Runtime baseline
-This page reflects the June 4, 2026 compatibility baseline: public npm runtime line `2.37.8`, with source pins tracked in [Runtime Compatibility Baseline](/rive/runtime-compatibility).
+This page reflects the released Web `2.40.0` -> C++ `runtime-v0.1.271` boundary, with source pins tracked in [Runtime Compatibility Baseline](/rive/runtime-compatibility).
 :::
 
 ---

--- a/docs/api/path-effects.mdx
+++ b/docs/api/path-effects.mdx
@@ -137,6 +137,14 @@ end
 
 **See Also:** [PathData](#pathdata), [PathMeasure](./drawing#pathmeasure)
 
+### Clipping and empty geometry
+
+In the target source snapshot, clipping uses the post-effect fill path. A
+scripted PathEffect can therefore change the clip geometry; an empty effect
+path clips everything, while strokes do not define the clip. Remove older
+warnings that PathEffects can never affect clipping and test the empty-path
+case explicitly.
+
 ---
 
 ## CommandType

--- a/docs/api/system.mdx
+++ b/docs/api/system.mdx
@@ -22,7 +22,7 @@ import Quiz from '@site/src/components/Quiz';
 System-level APIs and environment constraints.
 
 :::info Runtime baseline
-This page is aligned to the June 4, 2026 compatibility baseline: public npm runtime line `2.37.8`, with source pins tracked in [Runtime Compatibility Baseline](/rive/runtime-compatibility).
+This page is aligned to the released Web `2.40.0` -> C++ `runtime-v0.1.271` boundary, with source pins tracked in [Runtime Compatibility Baseline](/rive/runtime-compatibility).
 :::
 
 ---

--- a/docs/best-practices/performance.mdx
+++ b/docs/best-practices/performance.mdx
@@ -389,7 +389,7 @@ Shader workflows add GPU resources to the same lifecycle discipline:
 
 - Create pipelines, static vertex buffers, samplers, and stable bind groups in `init` or when inputs change.
 - Update small uniform buffers in `advance`; do not rebuild the pipeline every frame.
-- Keep `drawCanvas` focused on pass setup, binding existing resources, draw calls, and `pass:finish()`.
+- Keep GPU work at the start of `draw`, focused on pass setup, binding existing resources, draw calls, and `pass:finish()` before compositing.
 - Recreate size-dependent textures only from `resize` or explicit size changes.
 - Use immutable `GPUBuffer` objects for static geometry.
 - Prefer dynamic uniform buffers for many objects instead of creating many bind groups per frame.
@@ -405,7 +405,7 @@ For shader-specific API details, see [GPU Shaders](/api/gpu-shaders).
 - Fast scripts are about *when* and *where* you do work
 - Cache objects in `init`, rebuild on demand in `update`
 - Keep `draw` as lightweight as possible
-- Keep `drawCanvas` lightweight too: bind existing GPU resources and draw
+- Keep merged GPU work in `draw` lightweight: bind existing GPU resources and draw
 - Avoid allocations in hot loops
 - Use `context:markNeedsUpdate()` to signal the system when redraw is needed
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -10,6 +10,55 @@ All notable changes to the LERP (Luau Education for Rive Professionals) course a
 
 ---
 
+## [1.3.0] — 2026-08-14
+
+### Changed
+
+- **Runtime boundary refresh** — aligned the compatibility record to released
+  Web `2.40.0` backed by C++ `runtime-v0.1.271`; kept the parser canary
+  `runtime-v0.1.272` separate.
+- **Retired `drawCanvas` migration** — removed the callback from active Node,
+  Layout, lifecycle, quick-reference, shader, and lab guidance. Canvas and
+  GPUCanvas recording now belongs in `draw(self, renderer)` with balanced
+  frame/pass completion.
+- **Expanded callable API coverage** — documented source-confirmed 3D Vector
+  (`xyz`, `cross3`, buffer writes), `Mat4.lookAt`/`ortho`, partial GPU buffer
+  writes, source-only GPU texture-view format, Global ViewModels, Font/Blob
+  properties, and library-scoped assets with explicit rollout tiers.
+- **Lifecycle and correctness guidance** — covered detached ViewModel advance,
+  input wake-up, collapsed-node behavior, async context retention, converter
+  safety, unsigned colors, scripted clipping, TextInput behavior, stable asset
+  identity, and deferred Early Access GPU allocation.
+- **API boundaries** — marked host/embedder APIs and editor/export metadata
+  (including FileFormat/TextFileFormat and retired method bits) as non-callable
+  Luau surfaces.
+- **Deterministic discovery feeds** — AI feed generation now honors
+  `SOURCE_DATE_EPOCH` and otherwise derives a stable timestamp from this newest
+  release heading, so required generation and production builds are
+  byte-identical when source content is unchanged.
+- **[Errata LERP-GAP-017](./rive/rive-doc-errata)** — recorded the August 14
+  MCP-driven Rive Beta 0.8.5390 build 5377 validation of Vector/Mat4 math,
+  buffer writes, Mat2D/Mat4 equality, typed ViewModel lookups, the explicit
+  `any` cast required for Blob string/buffer/`nil` runtime writes, a successful
+  ranged GPUBuffer write with both overflow rejections, and the failed live
+  `GPUTextureView.format` access. Context global-VM, imported-library, broader
+  GPU lifecycle, and released Web 2.40.0 behavior remain unexecuted.
+- **[Errata LERP-ERR-018](./rive/rive-doc-errata)** — reconciled the complete
+  event surface to the live Editor reference and a diagnostics-clean analyzer
+  probe: current event names, exact `PointerType`, full gamepad payloads,
+  ListenerContext guards/accessors, and Node callbacks. Historical
+  `*Invocation` wrapper names are now source/runtime compatibility notes rather
+  than current Editor authoring guidance. The same probe accepted
+  `AudioSound:pause/resume/play`; event dispatch and audio calls remain
+  runtime-unexecuted.
+
+### Added
+
+- `learn_luau_rive_scripts/runtime-v0262-surface.luau` as the focused static/LSP
+  reconciliation fixture for the new math, ViewModel, and lifecycle surface.
+
+---
+
 ## [1.2.12] — 2026-06-14
 
 ### Added

--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -128,7 +128,10 @@ end
 
 ### AudioSound {#audiosound}
 
-A playing audio instance returned by `Audio.play()`. Provides playback control including `stop()`, `seek()`, `volume`, and `completed()`.
+A playing audio instance returned by `Audio.play()`. Provides playback control
+including `pause()`, `resume()`, `play()`, `stop()`, `seek()`, `volume`, and
+`completed()`. The current Editor reference/analyzer accepts the three transport
+methods; the August 14 probe did not execute them.
 
 ```lua
 local sound = Audio.play(source)
@@ -1634,18 +1637,23 @@ If omitted or failing, runtime falls back to linear interpolation.
 
 ---
 
-### drawCanvas() {#drawcanvas}
+### Retired `drawCanvas()` callback {#drawcanvas}
 
-An optional Node/Layout lifecycle callback for offscreen `Canvas` and early-access `GPUCanvas` rendering. Use it for `Canvas:beginFrame(...)` and `GPUCanvas:beginRenderPass(...)`; use `draw(self, renderer)` afterward to composite the resulting image.
+`drawCanvas` was the old Node/Layout lifecycle callback for offscreen Canvas
+and GPUCanvas work. It is retired in the target runtime: merge
+`Canvas:beginFrame(...)`/`endFrame()` or `GPUCanvas:beginRenderPass(...)`/`finish()`
+into `draw(self, renderer)`, then composite the image in that callback. The
+serialized method bit is reserved legacy metadata, not a callable API.
 
 ```lua
-function drawCanvas(self: ShaderNode)
+function draw(self: ShaderNode, renderer: Renderer)
     local pass = self.gpuCanvas:beginRenderPass({
         color = {{ loadOp = "clear", storeOp = "store", clearColor = { 0, 0, 0, 0 } }},
     })
     pass:setPipeline(self.pipeline)
     pass:draw(self.vertexCount)
     pass:finish()
+    renderer:drawImage(self.gpuCanvas.image, self.imageSampler, "srcOver", 1)
 end
 ```
 
@@ -1717,7 +1725,7 @@ fn fsMain() -> @location(0) vec4<f32> {
 
 | Category | Terms |
 |----------|-------|
-| **Lifecycle** | [init](#init), [update](#update), [advance](#advance), [drawCanvas](#drawcanvas), [draw](#draw), [Lifecycle](#lifecycle) |
+| **Lifecycle** | [init](#init), [update](#update), [advance](#advance), [draw](#draw), [Lifecycle](#lifecycle) |
 | **Types** | [export type](#export-type), [Generic](#generic), [Union Type](#union-type), [Optional Type](#optional-type), [Intersection Type](#intersection-type), [Type Alias](#type-alias), [Type Guard](#type-guard), [Type Narrowing](#type-narrowing) |
 | **Data** | [Input](#input), [Property](#property), [ViewModel](#viewmodel), [Trigger](#trigger), [Output](#output), [late()](#late), [Data Binding](#data-binding), [DataContext](#datacontext), [Listener](#listener) |
 | **Drawing** | [Path](#path), [Paint](#paint), [Renderer](#renderer), [Color](#color), [Gradient](#gradient), [Mat2D](#mat2d), [Mat4](#mat4), [Vector](#vector), [ImageSampler](#imagesampler) |

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -44,12 +44,23 @@ LERP teaches practical Luau for Rive creators through short lessons, buildable e
 
 LERP now tracks a pinned runtime audit baseline so you can verify exactly which APIs were confirmed at review time.
 
-- Public runtime release line: `2.37.8` (C++ WASM npm packages)
-- Public runtime npm gitHead: `bc560112ab2ee7d0afd3418bd97970c2fcb36532`
-- Source-level API audit snapshot: `runtime-v0.1.106` at `5360c834eac2adbdfc49c808d1b2a8c61b014bbf`
+- Released Web runtime line: `@rive-app/*@2.40.0`, backed by C++ `runtime-v0.1.271`
+- Released C++ runtime commit: `526625850eaf34fc1263d181808ffca10cae6ac1`
+- Released Web package gitHead: `1e9391880df1d501b98d165d2db89284025462eb`
+- Parser canary: `runtime-v0.1.272` remains separate from the released Web boundary
 - Shader/GPU rollout tier: Rive Early Access editor workflow only
-- Baseline revalidated: June 4, 2026
-- Full matrix: [Runtime Compatibility Baseline](/rive/runtime-compatibility)
+- Baseline revalidated: August 14, 2026
+- MCP editor validation: Rive Beta `0.8.5390` build `5377` passed the scoped Vector/Mat4/ViewModel cases, `Mat2D`/`Mat4` equality, and ranged `GPUBuffer` writes; Blob string/buffer/`nil` writes required an explicit `any` cast in the current editor checker
+- Analyzer validation: exact current event/gamepad declarations and `AudioSound:pause/resume/play` compiled with diagnostics `[]`; those callbacks/calls were not runtime-executed
+- Full matrix: [Runtime Compatibility Baseline](/rive/runtime-compatibility); validation details: [Rive Script Errata](/rive/rive-doc-errata#lerp-gap-017)
+
+The GPU evidence is deliberately narrow: `GPUBuffer`/`GPUTexture` constructors
+executed despite analyzer unknown-global diagnostics, while live
+`GPUTextureView.format` access failed. The probe does not establish
+`Context:globalViewModel*`, imported-library asset resolution, event/audio
+runtime dispatch, the broader GPUCanvas/shader lifecycle, or released Web
+behavior. Keep those boundaries preview/rollout-dependent until independently
+verified.
 
 ## What You'll Learn
 
@@ -85,7 +96,7 @@ Each section includes:
 - Click **linked terms** to see definitions
 - Use the **search** (Ctrl/Cmd + K) to find anything
 
-## Course at a Glance (Updated June 4, 2026)
+## Course at a Glance (Updated August 14, 2026)
 
 | Signal | Value | Why it matters |
 | --- | ---: | --- |

--- a/docs/projects/gpu-shader-labs.mdx
+++ b/docs/projects/gpu-shader-labs.mdx
@@ -26,9 +26,9 @@ Each lab has one `.wgsl` shader asset and one `.luau` <Term>Node</Term> script. 
 
 - create resources in local non-null variables in `init`
 - use typed descriptor locals for pipeline and bind-group arrays
-- do GPU render-pass work in `drawCanvas`
+- do GPU render-pass work at the start of `draw`, before compositing
 - composite `GPUCanvas.image` in `draw`
-- return early from `drawCanvas` when any optional GPU handle is missing
+- return early from `draw` when any optional GPU handle is missing
 
 ---
 
@@ -118,7 +118,7 @@ Checkpoints:
 - `hello_triangle.wgsl` is loaded with `context:shader("hello_triangle")`
 - vertex data is packed as `position.xy, color.rgb`
 - `makeTriangleVertexLayout()` returns `{ VertexBufferLayout }`
-- `drawCanvas` begins and finishes one render pass
+- `draw` begins and finishes one render pass before compositing
 - `draw` composites `gpu.image`
 
 This is the base template for a new shader node. If this lab fails, do not move on to image sampling or multi-pass rendering yet.

--- a/docs/quick-reference.mdx
+++ b/docs/quick-reference.mdx
@@ -21,7 +21,7 @@ See [Script Capability Matrix](/rive/script-capability-matrix) for a comprehensi
 :::
 
 :::info Need version-locked API status?
-See [Runtime Compatibility Baseline](/rive/runtime-compatibility) for the current C++ WASM runtime release line (`2.37.8`), npm source pin (`bc560112`), source-level API snapshot (`runtime-v0.1.106`), and shader/GPU Early Access tier.
+See [Runtime Compatibility Baseline](/rive/runtime-compatibility) for the released Web line (`2.40.0` -> C++ `runtime-v0.1.271`), separate parser canary pin, and shader/GPU Early Access tier.
 :::
 
 :::tip Writing scripts outside Rive?
@@ -67,14 +67,11 @@ return function(): Node<MyNode>
 end
 ```
 
-### Optional GPU/Canvas Phase
+### Canvas/GPU work inside `draw`
 ```lua
-function drawCanvas(self: MyNode)
-    -- Canvas:beginFrame(...) or GPUCanvas:beginRenderPass(...) work
-end
-
 function draw(self: MyNode, renderer: Renderer)
-    -- Composite canvas.image or gpuCanvas.image here
+    -- Pair Canvas:beginFrame/endFrame or GPUCanvas:beginRenderPass/finish.
+    -- Composite canvas.image or gpuCanvas.image with renderer here.
 end
 ```
 
@@ -82,8 +79,7 @@ end
 1. `init(self, context)` - once on start
 2. `update(self)` - when inputs change (NO context param!)
 3. `advance(self, seconds)` - every animation frame
-4. `drawCanvas(self)` - optional offscreen Canvas/GPUCanvas render phase
-5. `draw(self, renderer)` - on canvas repaint (keep pure, no state changes!)
+4. `draw(self, renderer)` - records optional offscreen Canvas/GPUCanvas work and composites on repaint
 
 ### Runtime Guardrails
 - Use pure Luau + Rive APIs; do not use Roblox runtime globals (`game`, `workspace`, `Instance`).
@@ -161,14 +157,25 @@ end
 ### ListenerContext Safe Payload Branching
 ```lua
 function performAction(self: MyAction, listenerContext: ListenerContext)
-    if listenerContext:isGamepad() then
-        local g = listenerContext:asGamepad()
+    if listenerContext:isGamepadEvent() then
+        local g = listenerContext:asGamepadEvent()
         if g then
-            print(g.deviceId, g.buttonMask, g.axis0)
+            print(g.changeKind, g.changeIndex, g.changeValue)
         end
+    elseif listenerContext:isGamepadConnected() then
+        local g = listenerContext:asGamepadConnected()
+        if g then print(g.deviceId, g.mapping, g.leftStick) end
+    elseif listenerContext:isGamepadDisconnected() then
+        local g = listenerContext:asGamepadDisconnected()
+        if g then print(g.deviceId) end
     end
 end
 ```
+
+Current Editor event names are `KeyboardEvent`, `TextInput`, `FocusEvent`,
+`ReportedEvent`, `ViewModelChange`, `NoneEvent`, `GamepadConnected`,
+`GamepadEvent`, and `GamepadDisconnected`. Older `*Invocation` names belong to
+pinned runtime-source compatibility, not new Editor-authored examples.
 
 ### Promise / async / await
 ```lua
@@ -242,7 +249,7 @@ function init(self: ShaderNode, context: Context): boolean
     return true
 end
 
-function drawCanvas(self: ShaderNode)
+function draw(self: ShaderNode, renderer: Renderer)
     if not self.pipeline or self.gpuCanvas.width == 0 then return end
     local pass = self.gpuCanvas:beginRenderPass({
         color = {{ loadOp = "clear", storeOp = "store", clearColor = { 0, 0, 0, 0 } }},
@@ -251,9 +258,6 @@ function drawCanvas(self: ShaderNode)
     pass:setVertexBuffer(0, self.vertexBuffer)
     pass:draw(self.vertexCount)
     pass:finish()
-end
-
-function draw(self: ShaderNode, renderer: Renderer)
     if self.gpuCanvas.width > 0 then
         renderer:drawImage(self.gpuCanvas.image, self.imageSampler, "srcOver", 1)
     end

--- a/docs/release-workflow.mdx
+++ b/docs/release-workflow.mdx
@@ -81,6 +81,13 @@ Regenerate derived discovery artifacts:
 npm run generate:ai-artifacts
 ```
 
+Generation is reproducible. By default, the `Generated` / `generatedAt`
+timestamp is derived from the newest release heading in `docs/changelog.mdx`
+at `00:00:00.000Z`. Re-running the command without source changes must therefore
+produce byte-identical files. Reproducible-build callers may override that
+default with an integer Unix timestamp in `SOURCE_DATE_EPOCH`; invalid values
+fail closed.
+
 Then run the production build again:
 
 ```bash

--- a/docs/rive/inputs.mdx
+++ b/docs/rive/inputs.mdx
@@ -936,6 +936,20 @@ ANSWER: 75%
 
 ---
 
+## TextInput behavior boundary
+
+Current TextInput behavior includes focus/cursor visibility, selection clearing
+on focus loss, clamped scrolling, Home/End and Shift+Home/End, Cmd/Ctrl+A,
+double-click word selection, and triple-click line selection. These are editor
+and runtime behavior corrections, not new Luau keyboard/text callback names.
+The pinned runtime source still contains `keyboardEvent` / `textEvent`
+callbacks with historical `KeyboardInvocation` / `TextInputInvocation`
+wrappers, but the August 14 current Editor `Node<T>` reference does not list
+those callbacks. In `ListenerContext`, the current Editor payload types are
+`KeyboardEvent` and `TextInput`. Do not invent TextInput methods in a script
+lesson, and confirm the editor node-setting surface before giving UI
+instructions.
+
 ## Knowledge Check
 
 <Quiz

--- a/docs/rive/protocols/converter-protocol.mdx
+++ b/docs/rive/protocols/converter-protocol.mdx
@@ -669,6 +669,13 @@ Your console output should display the formatted currency string.
 
 ---
 
+## Current runtime correctness notes
+
+The source snapshot hardens two-way converters against alternating DataValue
+types (for example Number to String and back) and guards an unhydrated converter before
+dereferencing it. The protocol signatures do not change: keep both conversion
+directions type-safe and test a two-way Number-to-String round trip.
+
 ## Self-Assessment Checklist
 
 - [ ] I understand when to use Converter Scripts

--- a/docs/rive/protocols/layout-protocol.mdx
+++ b/docs/rive/protocols/layout-protocol.mdx
@@ -81,10 +81,6 @@ function draw(self: MyLayout, renderer: Renderer)
     -- Custom rendering (optional)
 end
 
-function drawCanvas(self: MyLayout)
-    -- Offscreen Canvas/GPUCanvas rendering (optional)
-end
-
 -- Propose ideal size (only for "Hug" fit type)
 function measure(self: MyLayout): Vector
     return Vector.xy(200, 150)
@@ -103,7 +99,6 @@ return function(): Layout<MyLayout>
         init = init,
         advance = advance,
         update = update,
-        drawCanvas = drawCanvas,
         draw = draw,
         measure = measure,
         resize = resize,
@@ -126,8 +121,7 @@ end
 | `measure` | `(self: T): Vector` | No | Propose ideal size (Hug fit only) |
 | `update` | `(self: T)` | No | Respond to input changes |
 | `advance` | `(self: T, seconds: number): boolean` | No | Per-frame animation updates |
-| `drawCanvas` | `(self: T)` | No | Offscreen `Canvas` / `GPUCanvas` render phase |
-| `draw` | `(self: T, renderer: Renderer)` | No | Custom rendering |
+| `draw` | `(self: T, renderer: Renderer)` | No | Custom rendering plus any offscreen `Canvas` / `GPUCanvas` work |
 
 :::note Inherits Node Pointer Callbacks
 `Layout<T>` extends `Node<T>`, so pointer callbacks like `pointerDown`, `pointerMove`, `pointerUp`, and `pointerExit` are also available when needed.
@@ -195,7 +189,7 @@ Layout Scripts inherit all Node Script lifecycle functions:
 | `init(self, context)` | One-time initialization |
 | `advance(self, seconds)` | Per-frame updates (for animations) |
 | `update(self)` | React to <Term>Input</Term> changes |
-| `drawCanvas(self)` | Render into offscreen `Canvas` / `GPUCanvas` targets |
+| `draw(self, renderer)` | Render into offscreen `Canvas` / `GPUCanvas` targets and composite them |
 | `draw(self, renderer)` | Custom rendering |
 
 ---

--- a/docs/rive/protocols/listener-action-protocol.mdx
+++ b/docs/rive/protocols/listener-action-protocol.mdx
@@ -23,7 +23,14 @@ import Term from '@site/src/components/Term';
 ListenerAction scripts run custom code when a <Term>State Machine</Term> listener event fires. Unlike [Listeners](./listener-protocol) (which are function signatures for `addListener()`), ListenerAction is a **script type** that you attach to state machine listener events.
 
 :::info Runtime baseline
-This page is aligned to the June 4, 2026 compatibility baseline: public npm runtime line `2.37.8`, with source pins tracked in [Runtime Compatibility Baseline](/rive/runtime-compatibility).
+This page is aligned to the August 14, 2026 compatibility baseline: released Web runtime line `@rive-app/*@2.40.0` backed by C++ `runtime-v0.1.271`, with source pins tracked in [Runtime Compatibility Baseline](/rive/runtime-compatibility).
+:::
+
+:::note Current Editor type surface
+The current Rive Editor analyzer accepts `KeyboardEvent`, `TextInput`,
+`FocusEvent`, `ReportedEvent`, `ViewModelChange`, `NoneEvent`, and the three
+gamepad payload types below. Older `*Invocation` names remain relevant when
+reading pinned runtime source, but are not the current Editor reference names.
 :::
 
 **When to use ListenerAction scripts:**
@@ -79,14 +86,21 @@ end
 
 | Guard | Accessor | Typical fields |
 |---|---|---|
-| `isPointerEvent()` | `asPointerEvent()` | `id`, `position`, `type`, `previousPosition`, `timeStamp` |
-| `isKeyboardEvent()` | `asKeyboardEvent()` | `key`, `shift`, `control`, `alt`, `meta`, `phase` |
-| `isTextInput()` | `asTextInput()` | `text` |
-| `isFocus()` | `asFocus()` | `isFocus` |
-| `isReportedEvent()` | `asReportedEvent()` | `delaySeconds` (payload is limited at this baseline) |
-| `isViewModelChange()` | `asViewModelChange()` | kind/presence only (payload is limited at this baseline) |
-| `isGamepad()` | `asGamepad()` | `deviceId`, `buttonMask`, `axis0` |
-| `isNone()` | `asNone()` | fallback/unknown kind |
+| `isPointerEvent()` | `asPointerEvent(): PointerEvent?` | `id`, `position`, `type: PointerType` |
+| `isKeyboardEvent()` | `asKeyboardEvent(): KeyboardEvent?` | `key`, `shift`, `control`, `alt`, `meta`, `phase: KeyPhase` |
+| `isTextInput()` | `asTextInput(): TextInput?` | `text` |
+| `isFocus()` | `asFocus(): FocusEvent?` | `isFocus` |
+| `isReportedEvent()` | `asReportedEvent(): ReportedEvent?` | Presence/kind only in the current Editor reference |
+| `isViewModelChange()` | `asViewModelChange(): ViewModelChange?` | Presence/kind only in the current Editor reference |
+| `isGamepadConnected()` | `asGamepadConnected(): GamepadConnected?` | Full connected-device state |
+| `isGamepadEvent()` | `asGamepadEvent(): GamepadEvent?` | Change metadata plus full device state |
+| `isGamepadDisconnected()` | `asGamepadDisconnected(): GamepadDisconnected?` | `deviceId` |
+| `isNone()` | `asNone(): NoneEvent?` | Fallback/unknown kind |
+
+For gamepad state, the current reference includes `buttons`, `axes`, mapping
+metadata, named standard buttons, stick vectors, triggers, and the
+`buttonPressed`, `buttonValue`, and `axis` query methods. See the
+[Events API](/api/events#gamepad-events) for the complete field map.
 
 ### `perform(self, pointerEvent)` — Legacy/Deprecated
 

--- a/docs/rive/protocols/listener-protocol.mdx
+++ b/docs/rive/protocols/listener-protocol.mdx
@@ -22,7 +22,7 @@ Unlike Node, Layout, Converter, Path Effect, Util, and Test scripts, there is **
 :::
 
 :::info Runtime baseline
-This page is aligned to the June 4, 2026 compatibility baseline: public npm runtime line `2.37.8`, with source pins tracked in [Runtime Compatibility Baseline](/rive/runtime-compatibility). ListenerAction event payloads (including gamepad payload support) are documented in [Events → ListenerContext](/api/events#listenercontext).
+This page is aligned to the released Web `2.40.0` -> C++ `runtime-v0.1.271` boundary, with source pins tracked in [Runtime Compatibility Baseline](/rive/runtime-compatibility). ListenerAction event payloads are documented in [Events -> ListenerContext](/api/events#listenercontext); current gamepad payloads use separate connected/event/disconnected guards, accessors, and types.
 :::
 
 ## AE/JS Syntax Comparison

--- a/docs/rive/protocols/node-lifecycle.mdx
+++ b/docs/rive/protocols/node-lifecycle.mdx
@@ -78,10 +78,22 @@ Rive calls your script functions in a specific order. Understanding this lets yo
 1. `init(self, context)` - runs once at startup
 2. `update(self)` - runs when any <Term>Input</Term> changes (NO context param!)
 3. `advance(self, seconds)` - runs every playback frame (logic); at design time it only fires as zero-delta settle passes
-4. `drawCanvas(self)` - runs during the canvas render phase for offscreen `Canvas` / `GPUCanvas` work
-5. `draw(self, renderer)` - runs on canvas repaint (normal renderer compositing, keep pure!)
+4. `draw(self, renderer)` - records offscreen `Canvas` / `GPUCanvas` work and runs normal renderer compositing
 
 Pointer event handlers (`pointerDown`, `pointerMove`, etc.) run when the user interacts with the script node.
+
+### Lifecycle corrections in the current source snapshot
+
+- A parked Node (`advance` returned `false`) can wake when pointer, keyboard,
+  text, or gamepad input arrives. `false` still parks ordinary per-frame work.
+- Collapsed `ScriptedDrawable` nodes do not advance; do not use hidden nodes as
+  background workers. Editor reinitialization may still perform a zero-step
+  settle/update to record paused GPU content once.
+- Detached ViewModel instances owned by a script advance at frame end, so
+  triggers and listeners can reset. Bound instances are not double-advanced.
+- `async(...)` coroutines retain their scripting context across `await`; keep
+  ordinary disposed-object and lifetime checks, but do not warn that all
+  context-dependent calls are invalid after an await.
 
 ---
 
@@ -92,15 +104,17 @@ Pointer event handlers (`pointerDown`, `pointerMove`, etc.) run when the user in
 | **init** | Create paths, paints, listeners, long-lived objects | Once | `constructor()` |
 | **update** | Respond to input changes; rebuild paths or cached values | On input change | `componentDidUpdate()` |
 | **advance** | Update time-based state (movement, physics, timers) | Every playback frame (design mode: settle passes only) | `requestAnimationFrame` logic |
-| **drawCanvas** | Render into offscreen `Canvas` / `GPUCanvas` targets | During canvas render phase | WebGL/WebGPU render pass |
-| **draw** | Issue <Term>Renderer</Term> commands only (no state changes!) | On canvas repaint | Canvas `ctx.draw()` calls |
+| **draw** | Record offscreen targets, finish passes, issue <Term>Renderer</Term> commands, and composite images | On canvas repaint | Rive renderer / Early Access GPU |
 
 :::tip Performance Rule
 Put expensive work in `update` or `init`, not in `draw` or `advance`. Rebuilding geometry in `advance` (called every frame) wastes resources if inputs haven't changed.
 :::
 
 :::info Shader and offscreen canvas rule
-Call `Canvas:beginFrame(...)` and `GPUCanvas:beginRenderPass(...)` from `drawCanvas(self)`. Composite the resulting `canvas.image` or `gpuCanvas.image` from `draw(self, renderer)`.
+Call `Canvas:beginFrame(...)` and `GPUCanvas:beginRenderPass(...)` from
+`draw(self, renderer)`, pair them with `endFrame()`/`finish()`, then composite
+the resulting image in the same callback. `drawCanvas` is a retired callback;
+serialized method bit 15 is reserved for old files only.
 :::
 
 ---
@@ -191,9 +205,8 @@ flowchart TD
     F -->|no| H
 
     subgraph H[Frame Loop]
-        I[advance self, seconds] --> |Update timers<br/>Physics/movement| J[drawCanvas self]
-        J --> |Offscreen Canvas/GPUCanvas work| K[draw self, renderer]
-        K --> |Render commands only| L[next frame]
+        I[advance self, seconds] --> |Update timers<br/>Physics/movement| J[draw self, renderer]
+        J --> |Canvas/GPUCanvas work + compositing| L[next frame]
         L --> I
     end
 ```
@@ -648,9 +661,11 @@ return function(): Node<MyNode>
 end
 ```
 
-## Keyboard and Text Events
+## Keyboard and Text Events (Source/Runtime Compatibility)
 
-Node scripts can also handle keyboard and committed text input payloads:
+Pinned runtime source includes Node callbacks named `keyboardEvent` and
+`textEvent`, using the historical Lua wrapper names `KeyboardInvocation` and
+`TextInputInvocation`:
 
 ```lua
 function keyboardEvent(self: MyNode, event: KeyboardInvocation): boolean
@@ -670,7 +685,34 @@ function textEvent(self: MyNode, event: TextInputInvocation): boolean
 end
 ```
 
-If these callbacks return `true`, propagation stops. If they return `false` (or nothing), other listeners may still receive the event.
+If these callbacks return `true`, the pinned runtime source stops propagation.
+They are not listed in the August 14 current Editor `Node<T>` reference and were
+not executed in the current MCP probe, so treat them as source/runtime
+compatibility rather than current Editor-reference parity. Inside
+`ListenerContext`, use the current Editor names `KeyboardEvent` and `TextInput`.
+
+## Gamepad Events (Current Editor Reference)
+
+The current Editor `Node<T>` reference exposes three distinct callbacks:
+
+```lua
+function gamepadConnected(self: MyNode, event: GamepadConnected)
+    print("connected", event.deviceId, event.mapping)
+end
+
+function gamepadEvent(self: MyNode, event: GamepadEvent)
+    print(event.changeKind, event.changeIndex, event.changeValue)
+end
+
+function gamepadDisconnected(self: MyNode, event: GamepadDisconnected)
+    print("disconnected", event.deviceId)
+end
+```
+
+These signatures passed the August 14 Editor analyzer probe. Hardware gamepad
+dispatch was not executed. ListenerAction scripts use the matching
+`isGamepadConnected` / `isGamepadEvent` / `isGamepadDisconnected` guards and
+`as...` accessors documented in [Events](/api/events#gamepad-events).
 
 ---
 
@@ -876,7 +918,7 @@ ANSWER: interactive
     { text: "Automatically calls context:markNeedsUpdate()" },
     { text: "Converts the event to a PointerEvent" },
   ]}
-  explanation="In current runtime bindings, returning true from keyboardEvent/textEvent marks the event consumed and stops propagation."
+  explanation="In the pinned runtime-source callback contract, returning true from keyboardEvent/textEvent marks the event consumed and stops propagation. These callbacks are tracked as source/runtime compatibility because the current Editor Node reference does not list them."
 />
 
 ---

--- a/docs/rive/protocols/node-protocol.mdx
+++ b/docs/rive/protocols/node-protocol.mdx
@@ -217,17 +217,32 @@ Every Node script you write will follow this structure. The exported type define
 | Function | Required | Parameters | Return | Called When |
 |----------|----------|------------|--------|-------------|
 | `init` | ✅ Yes | `self`, `context` | `boolean` | Once at startup |
-| `draw` | Optional (needed to render) | `self`, `renderer` | none | On canvas repaint |
+| `draw` | Optional (needed to render) | `self`, `renderer` | none | Record optional offscreen Canvas/GPU work and issue normal Renderer commands on repaint |
 | `update` | Optional | `self` | none | <Term>Input</Term> changes |
 | `advance` | Optional | `self`, `seconds` | `boolean` | Every playback frame; design-mode settle passes (see below) |
-| `drawCanvas` | Optional | `self` | none | Canvas/GPU render phase before `draw` |
 | `pointerDown` | Optional | `self`, `event: PointerEvent` | none | Mouse/touch down |
 | `pointerMove` | Optional | `self`, `event: PointerEvent` | none | Mouse/touch move |
 | `pointerUp` | Optional | `self`, `event: PointerEvent` | none | Mouse/touch up |
 | `pointerExit` | Optional | `self`, `event: PointerEvent` | none | Pointer leaves node |
+| `gamepadConnected` | Optional | `self`, `event: GamepadConnected` | none | A gamepad session connects |
+| `gamepadEvent` | Optional | `self`, `event: GamepadEvent` | none | A gamepad button or axis changes |
+| `gamepadDisconnected` | Optional | `self`, `event: GamepadDisconnected` | none | A gamepad session disconnects |
+
+The three gamepad callbacks above are present in the current Editor `Node<T>`
+reference and passed an analyzer probe on August 14, 2026. That probe did not
+execute hardware gamepad dispatch. See [Events](/api/events#gamepad-events) for
+the full payload fields and the matching `ListenerContext` guard/accessor triad.
+
+Source-level `keyboardEvent` / `textEvent` callbacks are tracked separately in
+the [runtime compatibility baseline](/rive/runtime-compatibility): they are not
+listed in the current Editor `Node<T>` reference snapshot, so do not infer
+Editor-reference parity from the source wrapper names alone.
 
 :::info GPU and offscreen canvas callback
-Use `drawCanvas(self)` for `Canvas:beginFrame(...)` and `GPUCanvas:beginRenderPass(...)` work. Use `draw(self, renderer)` afterward to composite the resulting `canvas.image` or `gpuCanvas.image`.
+The retired `drawCanvas(self)` callback is not dispatched by the target runtime.
+Merge `Canvas:beginFrame(...)`/`endFrame()` or
+`GPUCanvas:beginRenderPass(...)`/`finish()` work into `draw(self, renderer)` and
+composite the resulting image there. Keep frame/pass completion balanced.
 :::
 
 :::info advance() return value — playback vs design mode

--- a/docs/rive/protocols/scripted-interpolator-protocol.mdx
+++ b/docs/rive/protocols/scripted-interpolator-protocol.mdx
@@ -21,7 +21,7 @@ import ExerciseValidator from '@site/src/components/ExerciseValidator';
 ScriptedInterpolator is a runtime-backed protocol for custom interpolation behavior.
 
 :::info Runtime status
-This protocol remains tracked in the June 4, 2026 compatibility baseline: public npm runtime line `2.37.8`, with source pins documented in [Runtime Compatibility Baseline](/rive/runtime-compatibility).
+This protocol remains tracked against released Web `2.40.0` -> C++ `runtime-v0.1.271`, with source pins documented in [Runtime Compatibility Baseline](/rive/runtime-compatibility).
 :::
 
 Use it when linear interpolation is not enough and you need script-defined easing at the interpolation level.

--- a/docs/rive/protocols/util-protocol.mdx
+++ b/docs/rive/protocols/util-protocol.mdx
@@ -76,6 +76,27 @@ Use Util scripts for:
 - Reusable data structures (springs, timers, palettes)
 - Constants and configuration
 
+## Library scope and dependency resolution
+
+When a Util, shader, or Blob is exported through an imported library, asset
+lookup can be scoped explicitly:
+
+```lua
+context:shader("bareName")
+context:shader("lib:LibraryLabel/path/to/shader")
+context:blob("bareName")
+context:blob("lib:LibraryLabel/path/to/blob")
+```
+
+Inside an imported library, a bare name prefers that library's scope and then
+host assets. At host scope, a bare name does not leak into a versioned library.
+Use the `lib:<label>/...` form when the authoring contract depends on a
+particular library. Export rewrites `require` dependencies to versioned flat
+keys (for example `draco@2/mesh`) so multiple library versions can coexist;
+trace output may show those keys. This is runtime/export source evidence from
+the v0.1.262 impact snapshot, not a promise that every editor/Web lane has the
+same library packaging behavior.
+
 :::note Key Difference
 Unlike Node scripts, Util scripts have no `init`, `draw`, or `advance` functions. They are pure modules that export functions and types.
 :::

--- a/docs/rive/rive-doc-errata.mdx
+++ b/docs/rive/rive-doc-errata.mdx
@@ -11,8 +11,8 @@ keywords:
 
 # LERP Rive Documentation Errata Tracker
 
-Last revalidated against runtime baseline: 2026-06-04 (`2.37.8` public npm line; source-level API snapshot `runtime-v0.1.106` / `5360c834`; shader/GPU editor workflow remains Early Access only)
-Last editor-validated errata batch: 2026-06-12 (Rive Early Access editor, live instrumented probe scripts and Test-protocol runtime checks via the Rive MCP)
+Last revalidated against the released runtime boundary: 2026-08-14 (`2.40.0` Web line -> C++ `runtime-v0.1.271`; shader/GPU editor workflow remains Early Access only). Historical errata entries retain their original evidence dates.
+Last editor-validated errata batch: 2026-08-14 (Rive Beta 0.8.5390 build 5377, MCP-driven Tests-protocol runtime validation plus current event-reference analyzer probe)
 Initial errata tracker open date: 2026-04-26
 
 Purpose: record LERP documentation inconsistencies, inaccuracies, and materially misleading gaps discovered while validating live Rive Editor behavior and current official Rive docs.
@@ -39,6 +39,8 @@ Entries are ordered newest first (freshest updates at the top).
 
 | ID | Area | Status | Severity | Short finding |
 |---|---|---|---|---|
+| LERP-ERR-018 | Event names and gamepad payloads | resolved | high | Current-facing pages used historical `*Invocation` wrapper names, extra PointerEvent fields, and a stale generic gamepad payload instead of the Editor-reference event names and connected/event/disconnected triad. |
+| LERP-GAP-017 | Runtime surface/editor type boundary | resolved | high | August 14 MCP validation records runtime passes for matrix equality and ranged GPUBuffer writes, the failed GPUTextureView format access, analyzer-only event/audio coverage, and the remaining Context/library/GPU/Web boundaries. |
 | LERP-GAP-016 | While loops / script timeout recovery | resolved | high | Resolved in LERP on 2026-06-14 after a report from Rive Community user [Avo](https://community.rive.app/u/7a2efe62): the submitted `Exercise4_WhileCountdown` file froze the Rive editor because its `while energy > 0 do` loop incremented `steps` but never changed `energy`, so `init()` never returned. Course now warns at the general while-loop section and inside the exercise itself. |
 | LERP-ERR-015 | Path winding / fill rule | resolved | high | Resolved in LERP on 2026-06-12 after a report from GitHub user [belal-sweileh](https://github.com/ivg-design/lerp/issues/2): Exercise 3's described point order wound the triangle counter-clockwise, which the current clockwise-fill renderer does not draw; exercise reordered and winding rule documented. |
 | LERP-ERR-011 | Node protocol | resolved | high | Resolved in LERP on 2026-06-12: `draw` was documented as required for add-menu listing; editor-validated that draw-less Node scripts list, place, and run. |
@@ -55,6 +57,138 @@ Entries are ordered newest first (freshest updates at the top).
 | LERP-GAP-003 | ViewModel context | resolved | medium | Resolved in LERP on 2026-04-26: `context:viewModel()` wording now describes immediate data-context behavior, with `context:rootViewModel()` explicitly documented for root/global state. |
 | LERP-ERR-002 | Path Effect / PathCommand | resolved | high | Resolved in LERP on 2026-04-26: Path Effect examples now use string command-name comparisons and clarify `CommandType` is not a guaranteed global table in editor scripts. |
 | LERP-ERR-001 | ListenerAction | resolved | high | Resolved in LERP on 2026-04-26: ListenerAction guidance now uses `performAction(self, listenerContext)` as preferred and marks `perform` legacy. |
+
+---
+
+## LERP-ERR-018 - Current Editor event names and gamepad triad {#lerp-err-018}
+
+Status: resolved in LERP 2026-08-14
+
+Severity: high
+
+Reported by:
+
+- MCP comparison against the live Rive Editor built-in `rive/artboards` and
+  `rive/interfaces` scripting references
+
+Affected local docs before fix:
+
+- `docs/api/events.mdx`
+- `docs/quick-reference.mdx`
+- `docs/rive/protocols/listener-action-protocol.mdx`
+- `docs/rive/protocols/node-protocol.mdx`
+- `docs/rive/protocols/node-lifecycle.mdx`
+- `docs/rive/runtime-compatibility.mdx`
+- `docs/rive/script-capability-matrix.mdx`
+- `docs/rive/script-types.mdx`
+
+What was wrong:
+
+- Current-facing event sections used the historical runtime wrapper names
+  `KeyboardInvocation`, `TextInputInvocation`, `FocusInvocation`,
+  `ReportedEventInvocation`, `ViewModelChangeInvocation`, and `NoneInvocation`
+  instead of the current Editor names `KeyboardEvent`, `TextInput`,
+  `FocusEvent`, `ReportedEvent`, `ViewModelChange`, and `NoneEvent`.
+- `PointerEvent` claimed `previousPosition` and `timeStamp`, which are not
+  fields in the current Editor reference; `type` was documented as a plain
+  string instead of the exact `PointerType` union.
+- Gamepad guidance collapsed all payloads into stale
+  `isGamepad()` / `asGamepad()` / `GamepadInvocation` APIs with an `axis0`
+  field. The current reference uses three distinct connected, changed, and
+  disconnected payloads.
+- `ReportedEvent.delaySeconds` was presented as current even though the current
+  Editor `ReportedEvent` reference exposes no public fields. That property is
+  evidenced only on the historical runtime `ReportedEventInvocation` wrapper.
+
+Evidence:
+
+- `rive/artboards` returned the exact `PointerType`, `PointerEvent`, `KeyPhase`,
+  event payload, gamepad field/method, and `ListenerContext` definitions.
+- `rive/interfaces` returned the exact optional Node callbacks
+  `gamepadConnected`, `gamepadEvent`, and `gamepadDisconnected`.
+- A temporary Tests script covering all of those types, fields, guards,
+  accessors, and Node callbacks recompiled with diagnostics `[]`. The probe was
+  removed; the original three `LERP_130_Runtime_Surface_Tests` cases still
+  passed and final diagnostics remained clean.
+- Pinned `runtime-v0.1.262` source confirms why older names exist:
+  `rive_lua_libs.hpp` and `lua_listener_invocation.cpp` register the historical
+  `*Invocation` Lua userdata wrappers, while that same source snapshot already
+  implements the three-way gamepad surface.
+
+Untested boundary:
+
+- The analyzer probe did not synthesize keyboard, focus, reported,
+  view-model-change, or hardware gamepad events. It proves current Editor type
+  acceptance, not runtime dispatch or released Web `2.40.0` behavior.
+
+Fix implemented in LERP (2026-08-14):
+
+- Replaced all current-facing event signatures with the exact Editor reference.
+- Added full gamepad state/change fields, query methods, ListenerContext triad,
+  and Node callbacks.
+- Moved old `*Invocation` names into explicitly historical/source-runtime
+  compatibility notes and removed unsupported current-facing fields.
+- Updated the compatibility matrix and changelog so analyzer acceptance,
+  source confirmation, runtime dispatch, and released Web claims remain
+  separate.
+
+---
+
+## LERP-GAP-017 - August 14 runtime surface validation and editor type-check boundary {#lerp-gap-017}
+
+Status: resolved in LERP 2026-08-14 (was gap)
+
+Severity: high
+
+Reported by:
+
+- MCP-driven live validation in a fresh Untitled composition, Rive Beta 0.8.5390 build 5377
+
+Affected local docs before fix:
+
+- `docs/api/core-types.mdx`
+- `docs/api/data-input.mdx`
+- `docs/api/data-values.mdx`
+- `docs/advanced/viewmodels.mdx`
+- `docs/rive/runtime-compatibility.mdx`
+
+Evidence:
+
+- The real Tests-protocol script `LERP_130_Runtime_Surface_Tests` recompiled successfully with final diagnostics `[]`.
+- `Vector.xyz`, `Vector.cross3`, vector buffer writes, and `Mat4.lookAt`/`Mat4.ortho` composition and `writeToBuffer` all passed.
+- `Mat2D` and `Mat4` equality passed live: identity matrices compared equal and translated matrices compared unequal.
+- `ViewModel1` exposed `fontProp: Property<Font>`, `imageProp: Property<Image>`, and `payload: Property<Blob>`. Typed `getBlob`/`getFont`/`getImage` lookup, missing/null behavior, and Blob string/buffer/`nil` runtime writes passed after an explicit `payload :: any` cast.
+- Before that cast, the current editor analyzer rejected the string, buffer, and `nil` setters with `Expected this to be Blob`. The course now teaches this distinction instead of presenting the runtime-accepted forms as unconditionally type-safe.
+- `Data.ViewModel1.new('name')` returned `nil`; `Data.ViewModel1.new()` succeeded.
+- `GPUBuffer:write(source, destinationOffset, sourceOffset, byteLength)` executed successfully for a valid range; both source- and destination-overflow probes were rejected.
+- The runtime executed `GPUBuffer`/`GPUTexture` constructors even though the current Editor analyzer reported those names as unknown globals.
+- `GPUTextureView.format` was executed and failed with `attempt to index userdata with 'format'`.
+- A temporary exact-reference probe accepted the current event/gamepad surface and `AudioSound:pause()`, `resume()`, and `play()` with diagnostics `[]`; this is analyzer evidence, not runtime dispatch/call evidence.
+
+Untested boundaries:
+
+- `Context:globalViewModel()` and `Context:globalViewModelNames()` were not executed.
+- Imported-library blob/shader resolution was not executed.
+- Event/gamepad dispatch and the `AudioSound` transport calls were not executed.
+- The broader GPUCanvas/render-pass/shader lifecycle was not executed and remains Early Access material. The ranged GPUBuffer operation is the narrow live exception; `GPUTextureView.format` is a recorded live failure, not an untested surface.
+- Released Web `2.40.0` behavior was not established by this editor probe.
+
+Why this matters:
+
+The runtime source snapshot, editor analyzer, and runtime behavior do not form
+one undifferentiated availability claim. Learners need the editor-confirmed
+subset, the explicit Blob cast requirement, the narrow GPUBuffer pass, the
+GPUTextureView failure, and the still-unexecuted Context/library/broader-GPU/Web
+boundaries to remain visible when choosing APIs for a course exercise.
+
+Fix implemented in LERP (2026-08-14):
+
+- Added this traceable errata entry and linked it from the 1.3.0 changelog.
+- Updated the core-types, ViewModel, data-value, and compatibility guidance with the Beta validation tier and the uncast Blob setter diagnostic.
+- Preserved preview/rollout-dependent wording for released Web, Context, imported-library, and broader GPU surfaces while recording the exact GPUBuffer pass and GPUTextureView failure.
+- Machine-readable validation evidence is retained with the 2026-08-14
+  release-suite run at `evidence/rive-editor/rive-editor-validation-2026-08-14.json`;
+  it is release evidence, not a public course route.
 
 ---
 

--- a/docs/rive/runtime-compatibility.mdx
+++ b/docs/rive/runtime-compatibility.mdx
@@ -22,20 +22,19 @@ This page tracks three independent dimensions for Luau surfaces:
 
 ## Baseline Snapshot
 
-- **Audit date:** June 4, 2026
+- **Audit date:** August 14, 2026
 - **Runtime repo:** `rive-app/rive-runtime`
-- **Current C++ WASM runtime release line (npm):** `2.37.8`
-- **Checked npm packages:** `@rive-app/canvas`, `@rive-app/canvas-lite`, `@rive-app/webgl2`, `@rive-app/canvas-advanced` (all resolved to `2.37.8`)
-- **Runtime source gitHead (npm metadata for `2.37.8` packages):** `bc560112ab2ee7d0afd3418bd97970c2fcb36532`
-- **npm publish timestamp for `@rive-app/canvas@2.37.8`:** May 21, 2026 18:06:40 UTC
-- **Docs comparison source:** `https://rive.app/docs/llms-full.txt` fetched June 4, 2026
-- **Source-level API snapshot checked:** `runtime-v0.1.106` at commit `5360c834eac2adbdfc49c808d1b2a8c61b014bbf`
+- **Released C++ WASM runtime line:** `@rive-app/*@2.40.0`, backed by `runtime-v0.1.271` at `526625850eaf34fc1263d181808ffca10cae6ac1`
+- **Released package gitHead:** `1e9391880df1d501b98d165d2db89284025462eb` (all four checked packages aligned)
+- **Canary parser pin:** `runtime-v0.1.272` remains a parser canary and is not the released Web boundary
+- **Docs comparison source:** local `/Users/ivg/github/rive-docs` and `/Users/ivg/github/rive-runtime-docs`, reviewed August 14, 2026
+- **Source-level impact snapshot:** runtime-v0.1.262 through the RFP-authored impact note; claims below distinguish that source evidence from the released Web line
 - **Superseded historical source audit:** `runtime-v0.1.64` at commit `b25a32218c6308ac8dc4b1cb69df62de84d78ba4`
 
 Use this snapshot when deciding whether LERP content is current for C++ runtime behavior.
 
 :::caution Separate runtime facts from editor rollout
-LERP now tracks the public package/docs baseline (`2.37.8`), the source-level API snapshot used for binding checks (`runtime-v0.1.106`), and the editor availability tier separately. Shader/GPU APIs are present in the source-level snapshot and public docs, but the shader asset workflow remains **Rive Early Access only** and should not be assumed available in standard workspaces.
+LERP now tracks the released package/docs baseline (`2.40.0` -> `runtime-v0.1.271`), the source-level impact snapshot, and the editor availability tier separately. Shader/GPU APIs remain **Rive Early Access only** unless a focused probe proves otherwise.
 :::
 
 :::note Source-of-truth rule
@@ -57,66 +56,94 @@ LERP uses the following tier labels:
 
 This prevents course drift when upstream API pages move faster than editor rollout.
 
+:::warning Released boundary versus source/canary evidence
+The accepted suite boundary is released Web `2.40.0` -> C++ `runtime-v0.1.271`.
+The RFP parser canary pin `runtime-v0.1.272` is intentionally separate. The
+new Luau surfaces below were identified in the v0.1.262 source impact snapshot;
+do not present them as released Web/editor behavior without a focused probe.
+:::
+
 ---
 
-## "Coming Soon" Reality Check
+## Current Editor Reference and "Coming Soon" Reality Check
 
 Status legend:
 - **Live:** Exposed and usable in current runtime bindings
-- **Partial:** Surface exists but is limited vs docs wording
+- **Analyzer-accepted:** The current Editor reference and checker accept the type/signature
+- **Source-confirmed:** The pinned runtime source contains the corresponding binding/dispatch path
 - **Not exposed:** Not currently available in Luau bindings at this baseline
 
-| Surface in docs | Runtime status | Notes |
+| Surface in docs | Current evidence | Notes |
 |---|---|---|
-| `FocusEvent` | **Live** | `listenerContext:asFocus()` returns focus payload with `isFocus` |
-| `KeyPhase` | **Live** | Exposed as `"down"`, `"repeat"`, `"up"` through keyboard invocation |
-| `KeyboardEvent` | **Live** | `key`, modifier flags, and `phase` are available |
-| `ListenerContext` | **Live** | `is...` / `as...` methods are implemented and wired |
-| `TextInput` | **Live** | `listenerContext:asTextInput().text` is available |
-| `NoneEvent` | **Live** | `isNone()` and `asNone()` are available |
+| `PointerType` + `PointerEvent.type` | **Analyzer-accepted; reference label still says "Coming soon"** | `PointerType` is the exact eight-string union used by `PointerEvent.type`; it is not a runtime enum table |
+| `KeyPhase` + `KeyboardEvent` | **Analyzer-accepted; source wrapper uses historical name** | Current fields are `key`, modifiers, and `phase`; pinned runtime source calls the Lua wrapper `KeyboardInvocation` |
+| `TextInput` | **Analyzer-accepted; source wrapper uses historical name** | Current reference exposes `text`; pinned runtime source calls the wrapper `TextInputInvocation` |
+| `FocusEvent` | **Analyzer-accepted; source wrapper uses historical name** | Current reference exposes `isFocus`; pinned runtime source calls the wrapper `FocusInvocation` |
+| `ReportedEvent` | **Analyzer-accepted; empty in current reference** | Do not teach `delaySeconds` as a current Editor field; that field belongs to the historical `ReportedEventInvocation` source wrapper |
+| `ViewModelChange` | **Analyzer-accepted; empty in current reference** | Current Editor reference exposes presence/kind only |
+| `NoneEvent` | **Analyzer-accepted; empty in current reference** | `isNone()` / `asNone()` are current; the pinned source wrapper name is `NoneInvocation` |
+| `GamepadMappingKind`, `GamepadConnected`, `GamepadEvent`, `GamepadDisconnected` | **Analyzer-accepted + source-confirmed** | Full connected/change state and query methods are referenced; hardware gamepad dispatch was not executed in the August 14 probe |
+| `ListenerContext` | **Analyzer-accepted + source-confirmed** | Current gamepad API is the connected/event/disconnected guard/accessor triad; generic `isGamepad()` / `asGamepad()` is stale |
+| Node `gamepadConnected` / `gamepadEvent` / `gamepadDisconnected` | **Analyzer-accepted + source-confirmed** | Exact current `Node<T>` signatures passed the analyzer probe; actual gamepad dispatch was not executed |
 | `NodeReadData.paint` + `node:asPath()` + `node:asPaint()` | **Live** | Paint/path access is implemented in Lua artboard bindings |
 | `AudioSource.duration` | **Live** | `source.duration` is exposed in Lua audio bindings |
-| `ReportedEvent` | **Partial** | Invocation exists; exposed payload is currently limited (`delaySeconds`) |
-| `ViewModelChange` | **Partial** | Invocation exists; payload wrapper is currently minimal |
-| `PointerType` | **Partial** | No standalone type table; `PointerEvent.type` string values are live |
 | `ViewModel.name` | **Not exposed** | Documented upstream but not exposed in current Lua ViewModel wrapper |
 | `Output` | **Not exposed** | No runtime Lua `Output` surface at this baseline |
 
 ---
 
-## Runtime Surfaces Tracked in Current Baseline
+## Runtime Surfaces Tracked in the August 14 Current Baseline
 
-The rows below were revalidated against the June 4 public package/docs baseline (`2.37.8`) and source-level API snapshot (`runtime-v0.1.106`). Shader/GPU rows are live in the checked source/docs, but remain Early Access editor workflow material.
+These rows are re-evaluated against the released Web `2.40.0` / C++
+`runtime-v0.1.271` boundary and the local source/docs snapshot reviewed on
+August 14. The **Evidence basis** column is deliberately separate from
+runtime status: the focused MCP passes covered Vector/Mat4/ViewModel behavior,
+matrix equality, a ranged `GPUBuffer` write, and exact analyzer-reference
+surfaces. They did not execute every row below.
 
-| Surface | Runtime status | LERP tier | Notes |
+| Surface | Runtime status | LERP tier | Evidence basis and notes |
 |---|---|---|---|
-| `Mat4` | **Live** | **Officially released** | Full constructors, multiplication, inversion, transpose, and vector transforms are bound |
-| `Promise`, `async`, `await` | **Live** | **Officially released** | Promise chaining/cancel/status APIs plus async coroutine bridge are available |
-| `ViewModel:getImage(name)` | **Live** | **Officially released** | Returns `Property<Image>?` |
-| `ViewModel:getIndex()` | **Live** | **Officially released** | Returns list-item index; returns `-1` when VM is not list-bound |
-| `PropertyList:removeAt`, `removeAllOf`, `clear` | **Live** | **Officially released** | Removal/clear operations are implemented, with 1-based `removeAt` input |
-| `ListenerContext:isGamepad()` / `asGamepad()` | **Live** | **Officially released** | Gamepad invocation payload is exposed (`deviceId`, `buttonMask`, `axis0`) |
-| Node `keyboardEvent(self, event)` | **Live** | **Officially released** | Returning `true` stops propagation |
-| Node `textEvent(self, event)` | **Live** | **Officially released** | Returning `true` stops propagation |
-| `context:canvas(options)` + `Canvas` methods | **Live** | **Officially released** | Offscreen canvas with `beginFrame` / `endFrame` / `resize`, plus `image/width/height` |
-| `context:decodeImage(buffer)` + `DecodedImage` | **Live** | **Officially released** | Promise resolves to `{ data, width, height }` RGBA premultiplied pixels |
-| `context:gpuCanvas(options)` + `GPUCanvas` | **Live** | **Rive Early Access only** | Runtime surface exists, but shader/GPU editor workflow availability currently requires Rive Early Access |
-| `context:features()` + `GPUFeatures` | **Live** | **Rive Early Access only** | Capability flags and limits for GPU preview workflows; relevant to Early Access shader material |
-| `context:shader(name)` + `Shader` | **Live** | **Rive Early Access only** | Requires shader assets and Early Access editor visibility; can return `nil` in non-enabled workflows |
-| `GPUBuffer`, `GPUTexture`, `GPUSampler`, `GPUBindGroup`, `GPUBindGroupLayout`, `GPUPipeline`, `GPURenderPass`, `GPUTextureView` | **Live** | **Rive Early Access only** | Exposed in the shader reference/runtime surface, but taught as Early Access until editor/tooling rollout is broad |
-| Scripted Interpolator protocol | **Live (runtime-backed)** | **Officially released** | `transform` / `transformValue` hooks available with linear fallback behavior |
+| `Mat4` | **Source-confirmed + MCP-tested subset** | **Officially released** | Runtime/docs confirm the broader constructors, multiplication, inversion, transpose, and transforms; MCP tested composition and buffer writing, not every method |
+| `Vector.xyz`, `Vector.cross3`, vector buffer writes | **Source-confirmed + MCP-tested** | **Preview / rollout-dependent** | Rive Beta 0.8.5390 build 5377 passed the named constructors, cross product, and buffer writes; released Web availability remains separate |
+| `Mat4.lookAt`, `Mat4.ortho` | **Source-confirmed + MCP-tested** | **Preview / rollout-dependent** | Rive Beta 0.8.5390 build 5377 passed both helpers, composition, and `writeToBuffer`; helpers do not make the scene graph generally 3D |
+| `Mat2D` / `Mat4` equality (`==`) | **Editor-reference-confirmed + MCP runtime-tested** | **Officially released** | Identity matrices compared equal and translated matrices compared unequal for both types in the live Tests-protocol probe |
+| `Promise`, `async`, `await` | **Source-confirmed** | **Officially released** | Runtime/docs confirm the chaining, cancellation/status, and coroutine bridge; not live-tested in the August 14 MCP script |
+| `ViewModel:getImage(name)` | **Source-confirmed + MCP-tested** | **Officially released** | Rive Beta 0.8.5390 build 5377 returned the typed image property; broader image workflows were not live-tested |
+| `Context:globalViewModel(name)` / `globalViewModelNames()` | **Source-confirmed** | **Preview / rollout-dependent** | Runtime/source docs describe named file-global models and unknown-name `nil`; explicitly not executed in the MCP probe |
+| `ViewModel:getFont(name)` / `getBlob(name)` | **Source-confirmed + MCP-tested** | **Preview / rollout-dependent** | Beta probe passed typed lookup and missing/null behavior; Blob string/buffer/`nil` writes passed only after `payload :: any`, while uncast values were rejected by the editor checker |
+| `ViewModel:getIndex()` | **Source-confirmed** | **Officially released** | Runtime/docs confirm list-item index and detached `-1`; not live-tested in the August 14 MCP script |
+| `PropertyList:removeAt`, `removeAllOf`, `clear` | **Source-confirmed** | **Officially released** | Runtime/docs confirm removal and clear operations, including 1-based `removeAt`; not live-tested in this probe |
+| Current event types + `ListenerContext` guard/accessor set | **Source-confirmed + Editor-analyzer-tested** | **Preview / rollout-dependent** | Exact Pointer/keyboard/text/focus/reported/view-model/none and three-way gamepad signatures passed with diagnostics `[]`; event dispatch was not executed |
+| Node `gamepadConnected` / `gamepadEvent` / `gamepadDisconnected` | **Source-confirmed + Editor-analyzer-tested** | **Preview / rollout-dependent** | Exact `Node<T>` callbacks passed the Editor checker; hardware gamepad dispatch was not executed |
+| `AudioSound:pause()` / `resume()` / `play()` | **Editor-reference-confirmed + Editor-analyzer-tested** | **Preview / rollout-dependent** | The exact no-argument transport methods passed with diagnostics `[]`; the calls were not runtime-executed |
+| Node `keyboardEvent(self, event)` | **Source-confirmed; absent from current Editor `Node<T>` reference** | **Preview / rollout-dependent** | Pinned runtime source uses `KeyboardInvocation` and stops propagation on `true`; not executed in the August 14 probe |
+| Node `textEvent(self, event)` | **Source-confirmed; absent from current Editor `Node<T>` reference** | **Preview / rollout-dependent** | Pinned runtime source uses `TextInputInvocation` and stops propagation on `true`; not executed in the August 14 probe |
+| `context:canvas(options)` + `Canvas` methods | **Source-confirmed** | **Officially released** | Runtime/docs confirm offscreen canvas frame/resize/image methods; not live-tested in this probe |
+| `context:decodeImage(buffer)` + `DecodedImage` | **Source-confirmed** | **Officially released** | Runtime/docs confirm the promise and RGBA payload shape; not live-tested in this probe |
+| `context:gpuCanvas(options)` + `GPUCanvas` | **Source/docs-confirmed; not runtime-tested** | **Rive Early Access only** | The broader GPUCanvas/render-pass lifecycle was not executed; one standalone GPUBuffer allocation/write probe does not establish this workflow |
+| `context:features()` + `GPUFeatures` | **Source/docs-confirmed; not runtime-tested** | **Rive Early Access only** | Capability flags/limits are documented for GPU preview; the live probe did not execute this Context method |
+| `context:shader(name)` + `Shader` | **Source/docs-confirmed; not runtime-tested** | **Rive Early Access only** | Shader asset lookup is documented, but the current Editor analyzer did not expose `Context.shader` and no imported shader asset was executed |
+| `GPUBuffer`, `GPUTexture`, `GPUSampler`, `GPUBindGroup`, `GPUBindGroupLayout`, `GPUPipeline`, `GPURenderPass`, `GPUTextureView` | **Mixed live evidence; analyzer omits GPU globals** | **Rive Early Access only** | `GPUBuffer`/`GPUTexture` constructors executed despite unknown-global analyzer diagnostics; the broader object-family lifecycle was not executed |
+| `GPUBuffer:write(source, destinationOffset, sourceOffset, byteLength)` | **MCP runtime-tested; analyzer omits `GPUBuffer`** | **Rive Early Access only** | A valid ranged write passed and both source- and destination-overflow cases were rejected in Rive Beta; this is narrow buffer evidence, not full GPU workflow validation |
+| `GPUTextureView.format` | **Source-confirmed; MCP runtime probe failed** | **Rive Early Access only** | Live access failed with `attempt to index userdata with 'format'`; do not teach it as a working property in this Editor build |
+| `drawCanvas` callback | **Source/docs-confirmed retired** | **Migration required** | Current guidance merges Canvas/GPUCanvas work into `draw(self, renderer)`; serialized bit 15 remains legacy metadata, not a callable callback |
+| Scripted Interpolator protocol | **Source/docs-confirmed** | **Officially released** | `transform` / `transformValue` hooks and linear fallback are documented/source-confirmed; not live-tested in this probe |
 
 ---
 
-## Shader Early-Access Baseline Addendum (June 4, 2026)
+## Historical (June 4, 2026) Shader Early-Access Baseline Addendum
 
-The public npm/docs baseline above has been rechecked at `2.37.8`, and the current source-level audit uses `runtime-v0.1.106`. Shader/GPU scripting is part of that current source snapshot, but this material is currently **Rive Early Access only** because the editor workflow for shader assets is not broadly available.
+This appendix preserves the June 4, 2026 shader audit evidence. It is not the
+current release baseline above: that historical pass used public npm/docs
+`2.37.8` and source-level `runtime-v0.1.106`. Shader/GPU scripting was and
+remains **Rive Early Access only** because the editor workflow for shader assets
+is not broadly available.
 
 Use this addendum as the source of truth for LERP's shader lessons, not as a signal that shader scripting is broadly released in standard Rive workspaces.
 
 - **Shader baseline date:** June 4, 2026
 - **Shader API source reviewed:** `runtime-v0.1.106` at commit `5360c834eac2adbdfc49c808d1b2a8c61b014bbf`
-- **Public docs source checked:** `https://rive.app/docs/llms-full.txt`, including GPUCanvas, GPU object-family pages, `context:gpuCanvas`, `context:features`, `context:shader`, and `drawCanvas`
+- **Public/local docs source checked:** current local scripting protocol pages and runtime source bindings; older `drawCanvas` examples are treated as migration inputs, not current guidance
 - **Local reference document:** `/Users/ivg/github/luau-scripting/rive_shader_api_reference_runtime_v0106_type_safe.md`
 - **Local example corpus:** `/Users/ivg/github/luau-scripting/gpu_shaders`
 - **Current availability tier:** **Rive Early Access only**
@@ -125,7 +152,7 @@ LERP now teaches the following shader-specific rules:
 
 | Surface | LERP guidance | Notes |
 |---|---|---|
-| `drawCanvas(self)` | Use for `Canvas:beginFrame(...)` and `GPUCanvas:beginRenderPass(...)` | `draw(self, renderer)` remains the normal compositing callback |
+| `draw(self, renderer)` | Record Canvas/GPUCanvas work and composite with `Renderer` | `drawCanvas` is retired; keep frame/pass pairing inside `draw` |
 | `context:shader(name)` | Use for compiled `.wgsl` shader asset lookup | Returns `Shader?`; guard `nil` |
 | `GPUCanvas.format` | Use for pipeline color-target format | Avoid hard-coded formats unless you intentionally own the render target |
 | `Image:view()` | Use to sample image assets in shader bind groups | Shader usage is Rive Early Access only because it depends on GPU workflow availability |
@@ -140,14 +167,16 @@ Compatibility naming note: older docs and examples may mention `context:loadShad
 
 - Teach `ListenerAction.performAction(self, listenerContext)` as the primary listener callback shape.
 - Use `listenerContext:is...()` and `listenerContext:as...()` for event-safe branching.
-- Treat `PointerEvent.type` as string-based (`"pointerDown"`, `"pointerMove"`, etc.).
+- Treat `PointerEvent.type` as the `PointerType` string union; do not invent a runtime enum table.
+- Use separate `isGamepadConnected/Event/Disconnected` and matching `as...` methods. Do not use the stale generic `isGamepad()` / `asGamepad()` form.
+- Use current Editor event type names in new examples. Keep `*Invocation` names only when explicitly discussing pinned source/runtime compatibility.
 - Do not teach `viewModel.name` as available in Luau at this baseline.
 - Do not present `Output<T>` as currently exposed in C++ Luau bindings.
 - For list-bound ViewModels, use `viewModel:getIndex()` and handle detached state (`-1`).
 - For `PropertyList:removeAt(index)`, use 1-based indices and validate bounds.
 - Keep GPU shader/pipeline material in **Rive Early Access only** sections until editor-side shader asset visibility is broadly available.
 - When `context:shader(name)` returns `nil`, treat that as a possible asset name, packaging, or rollout/tooling gap before assuming script logic failure.
-- Use `drawCanvas(self)` for GPU and offscreen-canvas render passes; use `draw(self, renderer)` to composite the resulting image.
+- Merge GPU/offscreen Canvas recording and normal compositing into `draw(self, renderer)`; keep `beginFrame`/`endFrame` and `beginRenderPass`/`finish` paired. `drawCanvas` is retired and its serialized method bit is reserved legacy metadata.
 
 ---
 
@@ -174,6 +203,44 @@ Compatibility naming note: older docs and examples may mention `context:loadShad
 ---
 
 ## Audit Protocol (what this update checked)
+
+For the August 14, 2026 pass, LERP used this verification sequence:
+
+1. **Released boundary and source separation**
+   - Pinned released Web `2.40.0` to C++ `runtime-v0.1.271` and recorded the aligned package `gitHead`.
+   - Kept parser canary `runtime-v0.1.272` and the RFP source-impact snapshot separate from released-runtime claims.
+2. **Live Editor runtime cases through the Rive MCP**
+   - Ran `LERP_130_Runtime_Surface_Tests` in Rive Beta 0.8.5390 build 5377.
+   - All three original Vector/Mat4/ViewModel cases passed with final diagnostics `[]`.
+   - Focused follow-up runtime assertions passed for `Mat2D`/`Mat4` equality and
+     ranged `GPUBuffer:write`; the valid range succeeded and both source- and
+     destination-overflow cases were rejected.
+   - `GPUTextureView.format` was also executed and failed with
+     `attempt to index userdata with 'format'`.
+3. **Current Editor reference and analyzer reconciliation**
+   - Retrieved `rive/artboards` and `rive/interfaces` from the live built-in scripting reference.
+   - Compiled a temporary Tests probe covering the exact event types,
+     `ListenerContext` guards/accessors, full gamepad fields/methods,
+     `AudioSound:pause/resume/play`, and Node gamepad callbacks; diagnostics
+     were `[]`.
+   - Recorded that the same analyzer omits the `GPUBuffer` and `GPUTexture`
+     globals even though their runtime constructors executed.
+   - Removed the temporary probe, reran the original three cases, and confirmed
+     final diagnostics remained clean.
+4. **Pinned runtime-source comparison**
+   - Confirmed why historical `*Invocation` names appear in
+     `runtime-v0.1.262` Lua userdata wrappers.
+   - Confirmed that the same source snapshot already uses the current
+     connected/event/disconnected gamepad triad, so LERP's former generic
+     `GamepadInvocation` surface was stale rather than a required compatibility
+     alias.
+5. **Explicit non-claims**
+   - The event probe validated analyzer acceptance, not keyboard/focus/reported/
+     view-model-change or hardware gamepad dispatch; the AudioSound transport
+     calls were likewise not executed.
+   - Released Web `2.40.0`, global ViewModel Context methods, imported-library
+     asset resolution, and the broader Early Access GPUCanvas/shader/lifecycle
+     workflow were not established by the Editor probe.
 
 For the June 4, 2026 pass, LERP used this verification sequence:
 

--- a/docs/rive/script-capability-matrix.mdx
+++ b/docs/rive/script-capability-matrix.mdx
@@ -23,7 +23,16 @@ Use this page when you need exact boundaries such as:
 - "Where do script inputs actually come from?"
 
 :::info Runtime baseline
-Matrix details are aligned to the June 4, 2026 compatibility baseline: public npm runtime line `2.37.8` plus source-level API snapshot `runtime-v0.1.106`. GPU callback guidance remains Rive Early Access editor workflow material. For versioned API-surface tracking, see [Runtime Compatibility Baseline](/rive/runtime-compatibility).
+Matrix details use the accepted released Web boundary `2.40.0` -> C++ `runtime-v0.1.271`; newer source findings are labelled preview/canary. GPU callback guidance remains Rive Early Access editor workflow material. For versioned API-surface tracking, see [Runtime Compatibility Baseline](/rive/runtime-compatibility).
+:::
+
+:::warning Three separate truths
+Runtime source registration, public documentation, and editor/release
+availability are separate claims. Parser JSON fields, serialized implemented
+method bits, `scriptProtocolValue`, dependency verification, and FileFormat /
+TextFileFormat metadata are not callable Luau APIs. Native host methods such as
+`StateMachineInstance:keyInput`, global-model binding, logging sinks, and
+module trace labels are also not Luau contracts.
 :::
 
 ---
@@ -34,8 +43,8 @@ This is the quickest way to see all runtime callback parameters by script type.
 
 | Script Type | Required Callbacks | Callback Parameters You Get |
 |-------------|--------------------|-----------------------------|
-| **Node** | `init`, `draw` | `context: Context` (`init`), `renderer: Renderer` (`draw`), no-argument canvas phase (`drawCanvas`), `seconds: number` (`advance`), `event: PointerEvent` (`pointerDown/Move/Up/Exit`), keyboard/text invocations (`keyboardEvent`, `textEvent`) |
-| **Layout** | `init`, `resize` | `context: Context` (`init`), `size: Vector` (`resize`), `renderer: Renderer` (`draw`), no-argument canvas phase (`drawCanvas`), `seconds: number` (`advance`) |
+| **Node** | `init`, `draw` | `context: Context` (`init`), `renderer: Renderer` (`draw`), Canvas/GPUCanvas work merged into `draw`, `seconds: number` (`advance`), `event: PointerEvent` (`pointerDown/Move/Up/Exit`), current Editor-reference gamepad payloads (`gamepadConnected/Event/Disconnected`); source/runtime-only keyboard/text callbacks are tracked separately |
+| **Layout** | `init`, `resize` | `context: Context` (`init`), `size: Vector` (`resize`), `renderer: Renderer` (`draw`), Canvas/GPUCanvas work merged into `draw`, `seconds: number` (`advance`) |
 | **Converter** | `convert`, `reverseConvert` | `input: DataInputs` (`convert`), `input: DataOutput` (`reverseConvert`), optional `context: Context` (`init`), optional `seconds: number` (`advance`) |
 | **Path Effect** | `update` | `inPath: PathData` + `node: NodeReadData` (`update`), `seconds: number` (`advance`), optional `context: Context` (`init`) |
 | **ListenerAction** | `performAction` | `listenerContext: ListenerContext` (`performAction`), optional `context: Context` (`init`) |
@@ -57,7 +66,7 @@ Legend: `✅` supported, `⚠️` conditional/indirect, `❌` not supported.
 | Read editor `Input<T>` fields | ✅ | ✅ | ⚠️ 1 | ✅ |
 | Access `Context` in `init` | ✅ | ✅ | ✅ | ✅ |
 | Custom render with `Renderer` | ✅ | ✅ | ❌ | ❌ |
-| Offscreen `Canvas` / `GPUCanvas` render phase | ⚠️ 5 | ⚠️ 5 | ❌ | ❌ |
+| Offscreen `Canvas` / `GPUCanvas` render work inside `draw` | ⚠️ 5 | ⚠️ 5 | ❌ | ❌ |
 | Receive `PointerEvent` directly | ✅ | ❌ | ❌ | ❌ |
 | Transform host `PathData` geometry | ❌ | ❌ | ❌ | ✅ |
 | Has per-frame callback | ✅ | ✅ | ⚠️ 4 | ✅ |
@@ -83,7 +92,7 @@ Notes:
 2. ListenerAction scripts are event-driven (`performAction(listenerContext)`). Pointer data is accessed through listener context when the listener event carries it.
 3. TransitionCondition scripts often use threshold-style inputs plus ViewModel/context state to decide `evaluate()`.
 4. Converter scripts can optionally define `advance(self, seconds)` for time-based conversion logic, but many converters are purely data-driven.
-5. Node and Layout scripts can use `drawCanvas(self)` for offscreen `Canvas` and early-access `GPUCanvas` render passes, then composite the resulting image from `draw(self, renderer)`.
+5. Node and Layout scripts merge offscreen `Canvas`/Early Access `GPUCanvas` render passes into `draw(self, renderer)` and composite the resulting image there. The retired `drawCanvas` name must not be added to new scripts.
 
 ### 2C) Script-by-Script Boundaries
 
@@ -105,7 +114,12 @@ Notes:
 3. **Nesting a Node script under a shape or group affects hierarchy behavior, not callback shape**. It changes local transform, inherited opacity, and draw order, but it does not pass an implicit host `NodeData` or parent `PathData` into Node callbacks.
 4. **`Listener<T>` is not a script type**; it is a function signature used by `addListener()`/`removeListener()` APIs.
 5. **Util/Test scripts are non-attached scripts**: Util is imported code; Test is manual test execution.
-6. **ListenerContext payload detail is not uniform across kinds** at this baseline (`ReportedEvent` and `ViewModelChange` are currently limited payloads).
+6. **ListenerContext payload detail is not uniform across kinds**. In the
+   August 14 current Editor reference, `ReportedEvent`, `ViewModelChange`, and
+   `NoneEvent` expose no public fields, while gamepad payloads use three
+   distinct connected/event/disconnected types with full state on the first
+   two. Historical `*Invocation` wrapper names belong to pinned runtime source,
+   not current Editor-authored examples.
 
 ---
 
@@ -122,7 +136,7 @@ Notes:
 | Need | Use |
 |------|-----|
 | Draw custom graphics every frame | **Node** (`draw`, optional `advance`) |
-| Render GPU shader effects or post-processing | **Node** or **Layout** with `drawCanvas` + `GPUCanvas`, preview / rollout-dependent |
+| Render GPU shader effects or post-processing | **Node** or **Layout** with merged `draw` + `GPUCanvas`, Early Access / rollout-dependent |
 | Position/size children in a layout | **Layout** (`resize`, optional `measure`) |
 | Transform binding values | **Converter** (`convert`, `reverseConvert`) |
 | Distort or rebuild existing shape path geometry | **Path Effect** (`update(inPath, node)`) |

--- a/docs/rive/script-types.mdx
+++ b/docs/rive/script-types.mdx
@@ -19,7 +19,7 @@ import Term from '@site/src/components/Term';
 Rive provides **8 script types**, each designed for a specific purpose. This page gives you the big picture — which script type to choose and when.
 
 :::info Runtime baseline
-This overview is aligned to the June 4, 2026 compatibility baseline: public npm runtime line `2.37.8` plus source-level API snapshot `runtime-v0.1.106`. GPU callback guidance remains Rive Early Access editor workflow material. For versioned API-surface tracking, see [Runtime Compatibility Baseline](/rive/runtime-compatibility).
+This overview is aligned to the released Web `2.40.0` -> C++ `runtime-v0.1.271` boundary. Newer source findings and GPU guidance remain explicitly tiered. For versioned API-surface tracking, see [Runtime Compatibility Baseline](/rive/runtime-compatibility).
 :::
 
 :::info Need Full Access/Limitations Matrix?
@@ -56,11 +56,12 @@ If you haven't read [How Rive Scripts Work](/getting-started/how-rive-scripts-wo
 **Use when:** You need animation logic, custom drawing, or interactive behavior on a node.
 
 **Key features:**
-- Lifecycle callbacks: `init`, `update`, `advance`, `drawCanvas`, `draw`
+- Lifecycle callbacks: `init`, `update`, `advance`, `draw`
 - Pointer event handlers: `pointerDown`, `pointerMove`, `pointerUp`
-- Text/keyboard handlers: `textEvent`, `keyboardEvent`
+- Current Editor-reference gamepad handlers: `gamepadConnected`, `gamepadEvent`, `gamepadDisconnected`
+- Source/runtime compatibility handlers: `textEvent`, `keyboardEvent` (not listed in the August 14 current Editor `Node<T>` reference)
 - Access to <Term>Renderer</Term> for custom drawing
-- Access to `Canvas` / `GPUCanvas` render phases for offscreen and shader workflows
+- Access to `Canvas` / `GPUCanvas` render work from `draw` for offscreen and shader workflows (Early Access for GPU)
 - Can have inputs from the editor
 
 **Placement:** A Node script is added to the artboard as a script node. You can leave it at the artboard root or nest it under a group/shape for normal hierarchy behavior such as transform inheritance and draw order. Nesting does not pass the parent shape's `NodeData` or `PathData` into the Node callbacks.

--- a/docs/site-map.mdx
+++ b/docs/site-map.mdx
@@ -44,12 +44,12 @@ Primary XML sitemap: [sitemap.xml](https://forge.mograph.life/apps/lerp/sitemap.
 ## Api
 
 - [API Reference](https://forge.mograph.life/apps/lerp/category/api-reference) - Complete Rive Luau API documentation organized by category.
-- [Assets](https://forge.mograph.life/apps/lerp/api/assets) - Image, ImageFilter, ImageSampler, and ImageWrap
+- [Assets](https://forge.mograph.life/apps/lerp/api/assets) - Image, Blob, AudioSource, AudioSound, sampling, and Early Access GPU texture-view boundaries
 - [Core Types](https://forge.mograph.life/apps/lerp/api/core-types) - Vector, Color, Mat2D, and Mat4 types
 - [Data & Input](https://forge.mograph.life/apps/lerp/api/data-input) - Input, Property, Context, and ViewModel for data binding
 - [Data Values](https://forge.mograph.life/apps/lerp/api/data-values) - DataValue types, Converter, and Property types
 - [Drawing](https://forge.mograph.life/apps/lerp/api/drawing) - Path, Paint, Gradient, and Renderer for custom drawing
-- [Events](https://forge.mograph.life/apps/lerp/api/events) - PointerEvent plus ListenerContext payload invocations for listener-driven scripts
+- [Events](https://forge.mograph.life/apps/lerp/api/events) - Current Editor event types, ListenerContext payloads, and Node gamepad callbacks
 - [GPU Shaders](https://forge.mograph.life/apps/lerp/api/gpu-shaders) - GPUCanvas, Shader, GPUPipeline, GPUBuffer, GPUTexture, GPUSampler, bind groups, and shader descriptor types
 - [Hierarchy](https://forge.mograph.life/apps/lerp/api/hierarchy) - NodeData, NodeReadData, and Layout
 - [Interpolation](https://forge.mograph.life/apps/lerp/api/interpolation) - ScriptedInterpolator runtime API surface and callback contracts

--- a/learn_luau_rive_scripts/runtime-v0262-surface.luau
+++ b/learn_luau_rive_scripts/runtime-v0262-surface.luau
@@ -1,0 +1,57 @@
+-- Runtime v0.1.262 source-surface probe.
+-- Static/LSP reconciliation fixture; runtime/editor behavior still requires
+-- an exported .riv and a focused probe in the selected lane.
+
+type RuntimeSurfaceProbe = {
+    vm: ViewModel?,
+    global: ViewModel?,
+    names: { string },
+    vectorBytes: buffer,
+}
+
+local function mathSurface(): buffer
+    local a = Vector.xyz(1, 0, 0)
+    local b = Vector.xyz(0, 1, 0)
+    local normal = Vector.cross3(a, b)
+    local view = Mat4.lookAt(Vector.xyz(0, 0, 4), Vector.xyz(0, 0, 0), Vector.xyz(0, 1, 0))
+    local projection = Mat4.ortho(-2, 2, -2, 2, 0.1, 100)
+    local bytes = buffer.create(32)
+    normal:writeToBuffer(bytes, 0)
+    normal:writeVec4(bytes, 16, view[1] + projection[1])
+    return bytes
+end
+
+function init(self: RuntimeSurfaceProbe, context: Context): boolean
+    self.names = context:globalViewModelNames()
+    self.global = context:globalViewModel("Theme")
+    self.vm = context:viewModel()
+    self.vectorBytes = mathSurface()
+
+    if self.vm then
+        local blob = self.vm:getBlob("payload")
+        if blob then
+            local writable = blob :: any
+            writable.value = "probe"
+            writable.value = buffer.create(0)
+            writable.value = nil
+        end
+    end
+
+    return true
+end
+
+function draw(self: RuntimeSurfaceProbe, renderer: Renderer)
+    -- drawCanvas is retired; Canvas/GPUCanvas work belongs here when the
+    -- selected Early Access/editor lane exposes those APIs.
+end
+
+return function(): Node<RuntimeSurfaceProbe>
+    return {
+        init = init,
+        draw = draw,
+        vm = nil,
+        global = nil,
+        names = {},
+        vectorBytes = buffer.create(32),
+    }
+end

--- a/scripts/generate-ai-artifacts.mjs
+++ b/scripts/generate-ai-artifacts.mjs
@@ -9,6 +9,39 @@ const staticDir = path.join(root, 'static');
 const wellKnownDir = path.join(staticDir, '.well-known');
 const canonicalBase = 'https://forge.mograph.life/apps/lerp';
 
+function resolveGeneratedAt() {
+  const sourceDateEpoch = process.env.SOURCE_DATE_EPOCH;
+  if (sourceDateEpoch !== undefined) {
+    if (!/^\d+$/.test(sourceDateEpoch)) {
+      throw new Error('SOURCE_DATE_EPOCH must be a non-negative integer number of seconds.');
+    }
+
+    const seconds = Number(sourceDateEpoch);
+    const timestamp = new Date(seconds * 1000);
+    if (!Number.isSafeInteger(seconds) || Number.isNaN(timestamp.getTime())) {
+      throw new Error('SOURCE_DATE_EPOCH is outside the supported JavaScript date range.');
+    }
+    return timestamp.toISOString();
+  }
+
+  const changelog = fs.readFileSync(path.join(docsDir, 'changelog.mdx'), 'utf8');
+  const releaseDateMatch = changelog.match(
+    /^## \[[^\]]+\]\s+(?:—|-)\s+(\d{4}-\d{2}-\d{2})\s*$/m,
+  );
+  if (!releaseDateMatch) {
+    throw new Error(
+      'Unable to derive a stable artifact timestamp from docs/changelog.mdx; set SOURCE_DATE_EPOCH.',
+    );
+  }
+
+  const releaseDate = releaseDateMatch[1];
+  const timestamp = new Date(`${releaseDate}T00:00:00.000Z`);
+  if (Number.isNaN(timestamp.getTime()) || timestamp.toISOString().slice(0, 10) !== releaseDate) {
+    throw new Error(`Invalid release date in docs/changelog.mdx: ${releaseDate}`);
+  }
+  return timestamp.toISOString();
+}
+
 function slugify(value) {
   return value
     .toLowerCase()
@@ -170,10 +203,10 @@ function buildDocuments() {
   return Array.from(byUrl.values());
 }
 
-function writeLlmsFull(documents) {
+function writeLlmsFull(documents, generatedAt) {
   const lines = [];
   lines.push('# LERP Full Knowledge Surface (llms-full)');
-  lines.push(`Generated: ${new Date().toISOString()}`);
+  lines.push(`Generated: ${generatedAt}`);
   lines.push(`Canonical: ${canonicalBase}/`);
   lines.push('Scope: Complete documentation route inventory with page metadata for AI retrieval and citation.');
   lines.push('');
@@ -206,10 +239,10 @@ function writeLlmsFull(documents) {
   fs.writeFileSync(path.join(wellKnownDir, 'llms-full.txt'), `See: ${canonicalBase}/llms-full.txt\n`);
 }
 
-function writeAiFeed(documents) {
+function writeAiFeed(documents, generatedAt) {
   const feed = {
     version: '1.0',
-    generatedAt: new Date().toISOString(),
+    generatedAt,
     canonical: `${canonicalBase}/`,
     site: {
       name: 'LERP',
@@ -362,8 +395,9 @@ if (!fs.existsSync(docsDir)) {
 
 fs.mkdirSync(wellKnownDir, { recursive: true });
 const documents = buildDocuments().sort((a, b) => a.url.localeCompare(b.url));
-writeLlmsFull(documents);
-writeAiFeed(documents);
+const generatedAt = resolveGeneratedAt();
+writeLlmsFull(documents, generatedAt);
+writeAiFeed(documents, generatedAt);
 writeCourseSitemap(documents);
 writeHtmlSiteMap(documents);
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -190,7 +190,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'html',
       value:
-        '<div class="sidebar-author-meta"><strong>Author:</strong> IVG Design (I.V.Gusinski)<br/><strong>Last reviewed:</strong> June 12, 2026<br/><strong>Editorial standard:</strong> <a href="/apps/lerp/editorial-methodology">Methodology</a> · <a href="/apps/lerp/corrections-policy">Corrections Policy</a> · <a href="/apps/lerp/contact-transparency">Contact</a></div>',
+        '<div class="sidebar-author-meta"><strong>Author:</strong> IVG Design (I.V.Gusinski)<br/><strong>Last reviewed:</strong> August 14, 2026<br/><strong>Editorial standard:</strong> <a href="/apps/lerp/editorial-methodology">Methodology</a> · <a href="/apps/lerp/corrections-policy">Corrections Policy</a> · <a href="/apps/lerp/contact-transparency">Contact</a></div>',
       defaultStyle: false,
     },
   ],

--- a/static/.well-known/ai-feed.json
+++ b/static/.well-known/ai-feed.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generatedAt": "2026-06-14T19:49:54.330Z",
+  "generatedAt": "2026-08-14T00:00:00.000Z",
   "canonical": "https://forge.mograph.life/apps/lerp/",
   "site": {
     "name": "LERP",
@@ -220,7 +220,7 @@
     {
       "id": "api-assets",
       "title": "Assets",
-      "description": "Image, ImageFilter, ImageSampler, and ImageWrap",
+      "description": "Image, Blob, AudioSource, AudioSound, sampling, and Early Access GPU texture-view boundaries",
       "url": "https://forge.mograph.life/apps/lerp/api/assets",
       "canonicalUrl": "https://forge.mograph.life/apps/lerp/api/assets",
       "group": "api",
@@ -232,7 +232,11 @@
         "reference",
         "assets",
         "image",
-        "imagefilter"
+        "imagefilter",
+        "blob",
+        "audio",
+        "audiosound",
+        "gputextureview"
       ],
       "sourcePath": "docs/api/assets.mdx",
       "contentType": "documentation",
@@ -326,7 +330,7 @@
     {
       "id": "api-events",
       "title": "Events",
-      "description": "PointerEvent plus ListenerContext payload invocations for listener-driven scripts",
+      "description": "Current Editor event types, ListenerContext payloads, and Node gamepad callbacks",
       "url": "https://forge.mograph.life/apps/lerp/api/events",
       "canonicalUrl": "https://forge.mograph.life/apps/lerp/api/events",
       "group": "api",

--- a/static/ai-feed.json
+++ b/static/ai-feed.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generatedAt": "2026-06-14T19:49:54.330Z",
+  "generatedAt": "2026-08-14T00:00:00.000Z",
   "canonical": "https://forge.mograph.life/apps/lerp/",
   "site": {
     "name": "LERP",
@@ -220,7 +220,7 @@
     {
       "id": "api-assets",
       "title": "Assets",
-      "description": "Image, ImageFilter, ImageSampler, and ImageWrap",
+      "description": "Image, Blob, AudioSource, AudioSound, sampling, and Early Access GPU texture-view boundaries",
       "url": "https://forge.mograph.life/apps/lerp/api/assets",
       "canonicalUrl": "https://forge.mograph.life/apps/lerp/api/assets",
       "group": "api",
@@ -232,7 +232,11 @@
         "reference",
         "assets",
         "image",
-        "imagefilter"
+        "imagefilter",
+        "blob",
+        "audio",
+        "audiosound",
+        "gputextureview"
       ],
       "sourcePath": "docs/api/assets.mdx",
       "contentType": "documentation",
@@ -326,7 +330,7 @@
     {
       "id": "api-events",
       "title": "Events",
-      "description": "PointerEvent plus ListenerContext payload invocations for listener-driven scripts",
+      "description": "Current Editor event types, ListenerContext payloads, and Node gamepad callbacks",
       "url": "https://forge.mograph.life/apps/lerp/api/events",
       "canonicalUrl": "https://forge.mograph.life/apps/lerp/api/events",
       "group": "api",

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -1,5 +1,5 @@
 # LERP Full Knowledge Surface (llms-full)
-Generated: 2026-06-14T19:49:54.328Z
+Generated: 2026-08-14T00:00:00.000Z
 Canonical: https://forge.mograph.life/apps/lerp/
 Scope: Complete documentation route inventory with page metadata for AI retrieval and citation.
 
@@ -21,12 +21,12 @@ Scope: Complete documentation route inventory with page metadata for AI retrieva
 | Dynamic Instantiation | https://forge.mograph.life/apps/lerp/advanced/instantiation | docs/advanced/instantiation.mdx |  |
 | Procedural Geometry | https://forge.mograph.life/apps/lerp/advanced/procedural | docs/advanced/procedural.mdx | Dynamic Path generation, animated shapes, and particle systems in Rive |
 | ViewModels | https://forge.mograph.life/apps/lerp/advanced/viewmodels | docs/advanced/viewmodels.mdx | Binding scripts to ViewModels for reactive data-driven animations |
-| Assets | https://forge.mograph.life/apps/lerp/api/assets | docs/api/assets.mdx | Image, ImageFilter, ImageSampler, and ImageWrap |
+| Assets | https://forge.mograph.life/apps/lerp/api/assets | docs/api/assets.mdx | Image, Blob, AudioSource, AudioSound, sampling, and Early Access GPU texture-view boundaries |
 | Core Types | https://forge.mograph.life/apps/lerp/api/core-types | docs/api/core-types.mdx | Vector, Color, Mat2D, and Mat4 types |
 | Data & Input | https://forge.mograph.life/apps/lerp/api/data-input | docs/api/data-input.mdx | Input, Property, Context, and ViewModel for data binding |
 | Data Values | https://forge.mograph.life/apps/lerp/api/data-values | docs/api/data-values.mdx | DataValue types, Converter, and Property types |
 | Drawing | https://forge.mograph.life/apps/lerp/api/drawing | docs/api/drawing.mdx | Path, Paint, Gradient, and Renderer for custom drawing |
-| Events | https://forge.mograph.life/apps/lerp/api/events | docs/api/events.mdx | PointerEvent plus ListenerContext payload invocations for listener-driven scripts |
+| Events | https://forge.mograph.life/apps/lerp/api/events | docs/api/events.mdx | Current Editor event types, ListenerContext payloads, and Node gamepad callbacks |
 | GPU Shaders | https://forge.mograph.life/apps/lerp/api/gpu-shaders | docs/api/gpu-shaders.mdx | GPUCanvas, Shader, GPUPipeline, GPUBuffer, GPUTexture, GPUSampler, bind groups, and shader descriptor types |
 | Hierarchy | https://forge.mograph.life/apps/lerp/api/hierarchy | docs/api/hierarchy.mdx | NodeData, NodeReadData, and Layout |
 | Interpolation | https://forge.mograph.life/apps/lerp/api/interpolation | docs/api/interpolation.mdx | ScriptedInterpolator runtime API surface and callback contracts |


### PR DESCRIPTION
## Summary

- align the LERP course and reference with runtime v0.1.262
- publish the reviewed v1.3.0 compatibility, API, protocol, navigation, and changelog updates
- make AI-artifact generation deterministic via SOURCE_DATE_EPOCH or the newest dated course release

## Candidate binding

- commit: `0566e6d066037a1de05b24560ef81856051f03cf`
- tree: `97fd5178b5a7622643bc12b0fd79325da40a727b`
- digest: `e7a0bcaa9c9148683e508bbf0f32d72b4b6a1452a6d98e48152a1b514973aa47`
- scope: 41 changed paths

## Validation

- deterministic artifact generation repeated byte-identically
- landing TypeScript no-emit check
- production build
- diff whitespace check